### PR TITLE
HTTP::Config handler priority

### DIFF
--- a/lib/HTTP/Config.pm
+++ b/lib/HTTP/Config.pm
@@ -423,6 +423,12 @@ Matches if either the request or the response have a header $field with the give
 
 Matches if the response object has that key, or the entry has the given value.
 
+=item m_priority => $number
+
+This rule will always match. The specified number will adjust the priority of this item in the
+returned set of items. Higher priority items will be returned before lower priority items, items
+default to a priority of 0. This rule has a higher ordering precedence than all other matching rules.
+
 =back
 
 =head1 SEE ALSO

--- a/lib/HTTP/Config.pm
+++ b/lib/HTTP/Config.pm
@@ -205,7 +205,7 @@ sub matching {
                 $order->[$o || 0] += $c;
             }
         }
-        $order->[7] ||= 0;
+        $order->[8] = $item->{'priority'};
         $item->{_order} = join(".", reverse map sprintf("%03d", $_ || 0), @$order);
         push(@m, $item);
     }

--- a/lib/HTTP/Config.pm
+++ b/lib/HTTP/Config.pm
@@ -165,6 +165,10 @@ my %MATCH = (
         return 1 if $response->{$k} eq $v;
         return 0;
     },
+    m_priority => sub {
+        my($v) = @_;
+        return $v + 0, 8;
+    },
 );
 
 sub matching {
@@ -183,7 +187,6 @@ sub matching {
  ITEM:
     for my $item (@$self) {
         my $order = [(0) x 9];
-        $order->[8] = $item->{'priority'} || 0;
         for my $ikey (keys %$item) {
             my $mkey = $ikey;
             my $k;

--- a/lib/HTTP/Config.pm
+++ b/lib/HTTP/Config.pm
@@ -182,7 +182,8 @@ sub matching {
     my @m;
  ITEM:
     for my $item (@$self) {
-        my $order;
+        my $order = [(0) x 9];
+        $order->[8] = $item->{'priority'} || 0;
         for my $ikey (keys %$item) {
             my $mkey = $ikey;
             my $k;
@@ -205,11 +206,10 @@ sub matching {
                 $order->[$o || 0] += $c;
             }
         }
-        $order->[8] = $item->{'priority'};
-        $item->{_order} = join(".", reverse map sprintf("%03d", $_ || 0), @$order);
+        $item->{_order} = $order;
         push(@m, $item);
     }
-    @m = sort { $b->{_order} cmp $a->{_order} } @m;
+    @m = sort { my $c;$c ||= $b->{_order}->[$_] <=> $a->{_order}->[$_] for(reverse (0..8));$c } @m;
     delete $_->{_order} for @m;
     return @m if wantarray;
     return $m[0];

--- a/t/base/http-config.t
+++ b/t/base/http-config.t
@@ -54,9 +54,9 @@ $conf->remove_items(m_domain => ".com");
 ok(j($conf->matching_items($response)), "success|GET|always");
 
 #test custom priority for items
-$conf->add_item("high priority", priority => '1000');
-$conf->add_item("medium priority", priority => '101');
-$conf->add_item("low priority", priority => -10, m_host_port => "www.example.com:443", m_path_prefix => "/foo");
+$conf->add_item("high priority", m_priority => '1000');
+$conf->add_item("medium priority", m_priority => '101');
+$conf->add_item("low priority", m_priority => -10, m_host_port => "www.example.com:443", m_path_prefix => "/foo");
 ok(j($conf->matching_items($response)), "high priority|medium priority|success|GET|always|low priority");
 
 $conf->remove_items;  # start fresh

--- a/t/base/http-config.t
+++ b/t/base/http-config.t
@@ -2,7 +2,7 @@
 
 use strict;
 use Test;
-plan tests => 14;
+plan tests => 15;
 
 use HTTP::Config;
 
@@ -52,6 +52,12 @@ ok(j($conf->matching_items($response)), ".com|success|GET|secure|always");
 $conf->remove_items(m_secure => 1);
 $conf->remove_items(m_domain => ".com");
 ok(j($conf->matching_items($response)), "success|GET|always");
+
+#test custom priority for items
+$conf->add_item("high priority", priority => '1000');
+$conf->add_item("medium priority", priority => '101');
+$conf->add_item("low priority", priority => -10, m_host_port => "www.example.com:443", m_path_prefix => "/foo");
+ok(j($conf->matching_items($response)), "high priority|medium priority|success|GET|always|low priority");
 
 $conf->remove_items;  # start fresh
 ok(j($conf->matching_items($response)), "");


### PR DESCRIPTION
this is a patch that adds support for specifying a custom priority for items in a HTTP::Config object.

I need this support to be able to attach several response_done handlers that need to fire in a specific order.

here is the RT for this issue: https://rt.cpan.org/Public/Bug/Display.html?id=59497
