### PR TITLE
Partial fix for Changes in Encode 2.40

### DIFF
--- a/lib/HTTP/Message.pm
+++ b/lib/HTTP/Message.pm
@@ -271,7 +271,7 @@ sub content_charset
 		return "US-ASCII" unless /[\x80-\xFF]/;
 		require Encode;
 		eval {
-		    Encode::decode_utf8($_, Encode::FB_CROAK());
+		    Encode::decode_utf8($_, Encode::FB_CROAK() | Encode::FB_LEAVE_SRC());
 		};
 		return "UTF-8" unless $@;
 		return "ISO-8859-1";


### PR DESCRIPTION
Hi Gisle,

With Encode 2.40, libwww-perl has four test failures in `t/base/message-charset.t`:

```
not ok 33
# Test 33 got: "" (t/base/message-charset.t at line 124)
#    Expected: "\xE5"
#  t/base/message-charset.t line 124 is: ok($r->decoded_content, chr(0xE5));
not ok 34
# Test 34 got: "" (t/base/message-charset.t at line 125)
#    Expected: "\xC3\xA5"
#  t/base/message-charset.t line 125 is: ok($r->decoded_content(charset => "none"), "\xC3\xA5");
not ok 35
# Test 35 got: "" (t/base/message-charset.t at line 126)
#    Expected: "\xC3\xA5"
#  t/base/message-charset.t line 126 is: ok($r->decoded_content(default_charset => "ISO-8859-1"), "\xC3\xA5");
not ok 36
# Test 36 got: "" (t/base/message-charset.t at line 127)
#    Expected: "\xC3\xA5"
#  t/base/message-charset.t line 127 is: ok($r->decoded_content(default_charset => "latin1"), "\xC3\xA5");
```

[According to Dan Kogai](https://rt.cpan.org/Ticket/Display.html?id=61456), the change in Encode 2.40 that triggers this is actually a bug fix. This patch partially fixes the issue, getting us down to just one test failure:

```
# Test 33 got: "\xC3\xA5" (t/base/message-charset.t at line 124)
#    Expected: "\xE5"
#  t/base/message-charset.t line 124 is: ok($r->decoded_content, chr(0xE5));
```

So it seems like something more might need to be done to properly detect the encoding. I'll poke around a bit more to see if I can figure it out.

—Theory
