### PR TITLE
env_proxy don't through https proxy information to Crytpt::SSLeay or IO::Socket::SSL .

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -947,6 +947,8 @@ sub env_proxy {
 	    $self->proxy($k, $v);
 	}
     }
+    # Pass https proxy information to Crypt::SSLeay or IO::Socket::SSL .
+    $self->{proxy}{https} = '' if defined $ENV{HTTPS_PROXY};
 }
 
 


### PR DESCRIPTION
We don' have the way to set https proxy by calling env_proxy() at the once.
I'm using proxy that send 'CONNECT' method to the host.

---

```
$ENV{HTTP_PROXY} = 'http://myproxy:8080';
my $ua = LWP::UserAgent->new;
$ua->env_proxy;
warn $ua->get('https://www.google.com')->content;

No good.
```

---

```
$ENV{HTTP_PROXY} = 'http://myproxy:8080';
$ENV{HTTPS_PROXY} = 'http://myproxy:8080';
my $ua = LWP::UserAgent->new;
$ua->env_proxy;
warn $ua->get('https://www.google.com')->content;

No good. Bad request.
```

---

```
$ua->proxy(['http', 'https'], 'http://myproxy:8080');
warn $ua->get('https://www.google.com')->content;

No good. Bad request.
```

---

```
$ENV{HTTP_PROXY} = 'http://myproxy:8080';
$ENV{HTTPS_PROXY} = 'http://myproxy:8080';
$ua->env_proxy;
$ua->proxy(['https'], '')
warn $ua->get('https://www.google.com')->content;

Succeeded.
```

---

This is cause that LWP::UserAgent is treaing https proxy as http proxy.
LWP::UserAgent is delegating https protocol to Crypt::SSLeay or IO::Socket::SSL . Thus LWP::UserAgent should through environment HTTS_PROXY.

Please check and include.

Best Regards, Thanks.
- Yasuhiro Matsumoto
