### PR TITLE
Untitled

### DIFF
--- a/lib/LWP/ConnCache.pm
+++ b/lib/LWP/ConnCache.pm
@@ -8,8 +8,11 @@ $VERSION = "6.00";
 
 sub new {
     my($class, %cnf) = @_;
-    my $total_capacity = delete $cnf{total_capacity};
-    $total_capacity = 1 unless defined $total_capacity;
+
+    my $total_capacity = 1;
+    if (exists $cnf{total_capacity}) {
+        $total_capacity = delete $cnf{total_capacity};
+    }
     if (%cnf && $^W) {
 	require Carp;
 	Carp::carp("Unrecognised options: @{[sort keys %cnf]}")


### PR DESCRIPTION
Hi,

I think that LWP::ConnCache new() constructor should handle situation when option 'total_capacity' passed and 'total_capacity' == undef:
my $c = LWP::ConnCache->new(total_capacity => undef);

In such case new() will have the same semantics for this option as the total_capacity() accessor have.
