### PR TITLE
Fix for content_ref handling when using the Expect header

### DIFF
--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -254,7 +254,15 @@ sub request
 	my $eof;
 	my $wbuf;
 	my $woffset = 0;
-	if (ref($content_ref) eq 'CODE') {
+      INITIAL_READ:
+	if ($write_wait) {
+	    # skip filling $wbuf when waiting for 100-continue
+	    # because if the response is a redirect or auth required
+	    # the request will be cloned and there is no way
+	    # to reset the input stream
+	    # return here via the label after the 100-continue is read
+	}
+	elsif (ref($content_ref) eq 'CODE') {
 	    my $buf = &$content_ref();
 	    $buf = "" unless defined($buf);
 	    $buf = sprintf "%x%s%s%s", length($buf), $CRLF, $buf, $CRLF
@@ -277,7 +285,7 @@ sub request
 	vec($fbits, fileno($socket), 1) = 1;
 
       WRITE:
-	while ($woffset < length($$wbuf)) {
+	while ($write_wait || $woffset < length($$wbuf)) {
 
 	    my $sel_timeout = $timeout;
 	    if ($write_wait) {
@@ -333,6 +341,7 @@ sub request
 		    if ($code eq "100") {
 			$write_wait = 0;
 			undef($code);
+			goto INITIAL_READ;
 		    }
 		    else {
 			$drop_connection++;


### PR DESCRIPTION
Hi Gisle,

I ran into an issue with libwww the other day, and I think I have a solution.  My use case is that I'm trying to upload large files using LWP::UserAgent and the url to which I'm posting requires digest authentication.  Now, because the files are large, I want to use the "Expect: 100-continue" header to get my 401 response without sending a huge request.  Also, because the files are large, I wan't to use dynamic file upload so the file is streamed directly from disk.  However, what I found was that those two options didn't quite work together.

After a little bit of digging, I figured out that what was happening was the code ref generated to perform the dynamic upload was being read once for the initial request -- the request that would cause the 401 response -- but the data was never being sent because of the expect header.  The problem was that once the 401 response comes back, the request is cloned and the previously read data is lost.

Since there is no (easy) way to reset the stream on the cloned request, I decide the best solution is to avoid the initial read until the continue response is received.  I've patched my repository, the fix isn't long and appears to work from what testing I've done.  I think this solves about half of bug #54705. Please have a look and thanks for the libwww, I use it all the time.

--Bryan
