### PR TITLE
Adding +/CRLF to x-www-form-urlencoded per standards

### DIFF
--- a/lib/HTTP/Request/Common.pm
+++ b/lib/HTTP/Request/Common.pm
@@ -81,6 +81,14 @@ sub POST
 	    my $url = URI->new('http:');
 	    $url->query_form(ref($content) eq "HASH" ? %$content : @$content);
 	    $content = $url->query;
+	    
+	    # Technically, x-www-form-urlencoded should use plus signs
+	    # and CR/LF, as it otherwise breaks HTML/4.01
+	    $content =~ s/\%20/+/g;
+	    
+	    $content =~ s/\%0D\%0A/\n/g;
+	    $content =~ s/\%0D|\%0A/\n/g;
+	    $content =~ s/\n/\%0D\%0A/g;
 	}
     }
 


### PR DESCRIPTION
Pluses look better.  Besides, it's still standard [HTML/4.01](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) (and will be in [HTML5](http://www.w3.org/TR/html5/association-of-controls-and-forms.html#url-encoded-form-data) as UNICODE):

```
17.13.4 Form content types

application/x-www-form-urlencoded  

This is the default content type. Forms submitted with this content type must be encoded as follows:

1. Control names and values are escaped. Space characters are replaced by `+', and then reserved characters are escaped as described
in [RFC1738], section 2.2: Non-alphanumeric characters are replaced by `%HH', a percent sign and two hexadecimal digits representing
the ASCII code of the character. Line breaks are represented as "CR LF" pairs (i.e., `%0D%0A').

2. The control names/values are listed in the order they appear in the document. The name is separated from the value by `=' and 
name/value pairs are separated from each other by `&'.
```
