### PR TITLE
can't parse_head for real request

### DIFF
--- a/lib/LWP/RobotUA.pm
+++ b/lib/LWP/RobotUA.pm
@@ -126,7 +126,8 @@ sub simple_request
 	$self->{'rules'}->parse($robot_url, ""); 
 
 	my $robot_req = HTTP::Request->new('GET', $robot_url);
-	my $parse_head = $self->parse_head(0);
+	my $parse_head = $self->parse_head;
+	$self->parse_head(0);
 	my $robot_res = $self->request($robot_req);
 	$self->parse_head($parse_head);
 	my $fresh_until = $robot_res->fresh_until;


### PR DESCRIPTION
```perl
use LWP::RobotUA;
use LWP::UserAgent;
# my $ua = LWP::UserAgent->new;

my $ua = LWP::RobotUA->new(agent => "MySpider", from => 'test@test.com');
$ua->delay(0);

my $url = "http://www.51youpin.com/shop/category-1010117.html";
my $resp = $ua->get($url);

print $resp->base, "\n";
```

Why RobotUA can't get the base and the UserAgent can. parse_head has problem.
