### PR TITLE
Fix digest authentication failure if nonce is expired

### DIFF
--- a/lib/LWP/Authen/Basic.pm
+++ b/lib/LWP/Authen/Basic.pm
@@ -8,6 +8,10 @@ sub auth_header {
     return "Basic " . MIME::Base64::encode("$user:$pass", "");
 }
 
+sub reauth_requested {
+    return 0;
+}
+
 sub authenticate
 {
     my($class, $ua, $proxy, $auth_param, $response,
@@ -34,9 +38,10 @@ sub authenticate
     });
     $h->{auth_param} = $auth_param;
 
-    if (!$proxy && !$request->header($auth_header) && $ua->credentials($host_port, $realm)) {
+    my $reauth_requested = $class->reauth_requested( $auth_param, $ua, $request, $auth_header );
+    if (!$proxy && ( !$request->header($auth_header) || $reauth_requested ) && $ua->credentials($host_port, $realm)) {
 	# we can make sure this handler applies and retry
-        add_path($h, $url->path);
+        add_path($h, $url->path) unless $reauth_requested; # Do not clobber up path list for retries
         return $ua->request($request->clone, $arg, $size, $response);
     }
 

--- a/lib/LWP/Authen/Digest.pm
+++ b/lib/LWP/Authen/Digest.pm
@@ -5,6 +5,19 @@ use base 'LWP::Authen::Basic';
 
 require Digest::MD5;
 
+sub reauth_requested {
+    my( $class, $auth_param, $ua, $request, $auth_header ) = @_;
+    my $ret = defined( $$auth_param{ stale } ) && lc( $$auth_param{ stale } ) eq 'true';
+    if ( $ret ) {
+        my $hdr = $request->header( $auth_header );
+	$hdr =~ tr/,/;/;  # "," is used to separate auth-params!!
+	($hdr) = HTTP::Headers::Util::split_header_words( $hdr );
+	my $nonce = { @$hdr }->{ nonce };
+	delete $$ua{ authen_md5_nonce_count }{ $nonce };
+    }
+    return $ret;
+}
+
 sub auth_header {
     my($class, $user, $pass, $request, $ua, $h) = @_;
 


### PR DESCRIPTION
This change fixes the digest authentication failure described in issue #39.

An additional method reauth_requested() is introduced to the authentication mechanism. It shall indicate that the server suggests a reauthentication even if the authentication attempt fails.

It is always false for the basic authentication and all classes inheriting from that, unless they override it. For the digest authentication, it also returns false, unless the nonce is expired, indicated by the "stale=true" authentication parameter. In this case, the stale nonce from the request is deleted from the history, and the request is retried.

Tests were added to check this new behavior.
