### PR TITLE
env_proxy: skip https_proxy so SSLeay will handle it

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1009,6 +1009,10 @@ sub env_proxy {
 	$k = lc($k);
 	next unless $k =~ /^(.*)_proxy$/;
 	$k = $1;
+        if ($k eq 'https') {
+            # let SSLeay handle the proxy
+            next ;
+        } ;
 	if ($k eq 'no') {
 	    $self->no_proxy(split(/\s*,\s*/, $v));
 	}


### PR DESCRIPTION
As mentioned in https://rt.cpan.org/Ticket/Display.html?id=1894 , this patch enables `LWP::UserAgent` to defer `https` proxy to `SSLeay`.

This way, proxy configured from environment variables will use `CONNECT` for `https` connections and will behave as usual for `http` connection.

HTH
