### PR TITLE
Check $ENV{TMPDIR} before other paths

### DIFF
--- a/t/local/get.t
+++ b/t/local/get.t
@@ -10,7 +10,7 @@ if ($^O eq "MacOS") {
 
 # First locate some suitable tmp-dir.  We need an absolute path.
 $TMPDIR = undef;
-for ("/tmp/", "/var/tmp", "/usr/tmp", "/local/tmp") {
+for ($ENV{TMPDIR}, "/tmp/", "/var/tmp", "/usr/tmp", "/local/tmp") {
     if (open(TEST, ">$_/test-$$")) {
         close(TEST);
 	unlink("$_/test-$$");

--- a/t/local/get.t
+++ b/t/local/get.t
@@ -8,9 +8,11 @@ if ($^O eq "MacOS") {
 }
 
 
+use File::Temp 'tempdir';
+
 # First locate some suitable tmp-dir.  We need an absolute path.
 $TMPDIR = undef;
-for ($ENV{TMPDIR}, "/tmp/", "/var/tmp", "/usr/tmp", "/local/tmp") {
+for (tempdir()) {
     if (open(TEST, ">$_/test-$$")) {
         close(TEST);
 	unlink("$_/test-$$");
@@ -18,7 +20,6 @@ for ($ENV{TMPDIR}, "/tmp/", "/var/tmp", "/usr/tmp", "/local/tmp") {
 	last;
     }
 }
-$TMPDIR ||= $ENV{TEMP} if $^O eq 'MSWin32';
 unless ($TMPDIR) {
    # Can't run any tests
    print "1..0\n";

--- a/t/local/httpsub.t
+++ b/t/local/httpsub.t
@@ -1,5 +1,7 @@
 #!perl
 
+BEGIN { eval { require Data::Dump; 1 } || do { print "1..0 # SKIP Data::Dump is not installed\n"; exit 0 } }
+
 print "1..1\n";
 print "ok 1\n";
 


### PR DESCRIPTION
On Android:

```
$ prove -v -bl t/local/get.t 
t/local/get.t .. 
1..0
ok 1
skipped: (no reason given)

Test Summary Report
-------------------
t/local/get.t (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
  Parse errors: Bad plan.  You planned 0 tests but ran 1.
```

It is because this test assumes that $TMPDIR is one of hardcoded dirs which don't exist on Android.

I suggest to use $TMPDIR before other dirs as workaround.
