### PR TITLE
Comment from Petr Pisar points out that our strict regex checking of the...

### DIFF
--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -19,9 +19,7 @@ sub _new_socket
 
     # IPv6 literal IP address should be [bracketed] to remove
     # ambiguity between ip address and port number.
-    # Extra cautious to ensure that $host is _just_ an IPv6 address
-    # (at least as best as we can tell).
-    if ( ($host =~ /:/) && ($host =~ /^[0-9a-f:.%]+$/i) ) {
+    if ( ($host =~ /:/) && ($host !~ /^\[/) ) {
       $host = "[$host]";
     }
 


### PR DESCRIPTION
... address missed the "%" character.

Added; and tested.
