### PR TITLE
change EAGAIN to EWOULDBLOCK to support Windows too

### DIFF
--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -282,7 +282,7 @@ sub request
             my $n = $socket->syswrite($req_buf, length($req_buf));
             unless (defined $n) {
                 redo WRITE if $!{EINTR};
-                if ($!{EAGAIN}) {
+                if ($!{EWOULDBLOCK}) {
                     select(undef, undef, undef, 0.1);
                     redo WRITE;
                 }
@@ -352,7 +352,7 @@ sub request
             {
                 my $nfound = select($rbits, $wbits, undef, $sel_timeout);
                 if ($nfound < 0) {
-                    if ($!{EINTR} || $!{EAGAIN}) {
+                    if ($!{EINTR} || $!{EWOULDBLOCK}) {
                         if ($time_before) {
                             $sel_timeout = $sel_timeout_before - (time - $time_before);
                             $sel_timeout = 0 if $sel_timeout < 0;
@@ -373,7 +373,7 @@ sub request
 		my $buf = $socket->_rbuf;
 		my $n = $socket->sysread($buf, 1024, length($buf));
                 unless (defined $n) {
-                    die "read failed: $!" unless  $!{EINTR} || $!{EAGAIN};
+                    die "read failed: $!" unless  $!{EINTR} || $!{EWOULDBLOCK};
                     # if we get here the rest of the block will do nothing
                     # and we will retry the read on the next round
                 }
@@ -404,7 +404,7 @@ sub request
 	    if (defined($wbits) && $wbits =~ /[^\0]/) {
 		my $n = $socket->syswrite($$wbuf, length($$wbuf), $woffset);
                 unless (defined $n) {
-                    die "write failed: $!" unless $!{EINTR} || $!{EAGAIN};
+                    die "write failed: $!" unless $!{EINTR} || $!{EWOULDBLOCK};
                     $n = 0;  # will retry write on the next round
                 }
                 elsif ($n == 0) {
@@ -461,7 +461,7 @@ sub request
 	{
 	    $n = $socket->read_entity_body($buf, $size);
             unless (defined $n) {
-                redo READ if $!{EINTR} || $!{EAGAIN} || $!{ENOTTY};
+                redo READ if $!{EINTR} || $!{EWOULDBLOCK} || $!{ENOTTY};
                 die "read failed: $!";
             }
 	    redo READ if $n == -1;

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -282,7 +282,7 @@ sub request
             my $n = $socket->syswrite($req_buf, length($req_buf));
             unless (defined $n) {
                 redo WRITE if $!{EINTR};
-                if ($!{EWOULDBLOCK}) {
+                if ($!{EWOULDBLOCK} || $!{EAGAIN}) {
                     select(undef, undef, undef, 0.1);
                     redo WRITE;
                 }
@@ -352,7 +352,7 @@ sub request
             {
                 my $nfound = select($rbits, $wbits, undef, $sel_timeout);
                 if ($nfound < 0) {
-                    if ($!{EINTR} || $!{EWOULDBLOCK}) {
+                    if ($!{EINTR} || $!{EWOULDBLOCK} || $!{EAGAIN}) {
                         if ($time_before) {
                             $sel_timeout = $sel_timeout_before - (time - $time_before);
                             $sel_timeout = 0 if $sel_timeout < 0;
@@ -373,7 +373,7 @@ sub request
 		my $buf = $socket->_rbuf;
 		my $n = $socket->sysread($buf, 1024, length($buf));
                 unless (defined $n) {
-                    die "read failed: $!" unless  $!{EINTR} || $!{EWOULDBLOCK};
+                    die "read failed: $!" unless  $!{EINTR} || $!{EWOULDBLOCK} || $!{EAGAIN};
                     # if we get here the rest of the block will do nothing
                     # and we will retry the read on the next round
                 }
@@ -404,7 +404,7 @@ sub request
 	    if (defined($wbits) && $wbits =~ /[^\0]/) {
 		my $n = $socket->syswrite($$wbuf, length($$wbuf), $woffset);
                 unless (defined $n) {
-                    die "write failed: $!" unless $!{EINTR} || $!{EWOULDBLOCK};
+                    die "write failed: $!" unless $!{EINTR} || $!{EWOULDBLOCK} || $!{EAGAIN};
                     $n = 0;  # will retry write on the next round
                 }
                 elsif ($n == 0) {
@@ -461,7 +461,7 @@ sub request
 	{
 	    $n = $socket->read_entity_body($buf, $size);
             unless (defined $n) {
-                redo READ if $!{EINTR} || $!{EWOULDBLOCK} || $!{ENOTTY};
+                redo READ if $!{EINTR} || $!{EWOULDBLOCK} || $!{EAGAIN} || $!{ENOTTY};
                 die "read failed: $!";
             }
 	    redo READ if $n == -1;


### PR DESCRIPTION
This is the same problem described in https://github.com/libwww-perl/net-http/pull/11 for Net::HTTP, but this time for libwww-perl. Both patches need to go together.