### PR TITLE
Adaptation for checking version of all modules

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,7 +34,7 @@ flag_file("t/live/jigsaw/ENABLED", $opt{'jigsaw-tests'});
 
 WriteMakefile(
     NAME => 'LWP',
-    DISTNAME => 'libwww-perl',
+    DISTNAME => 'LWP',
     VERSION_FROM => 'lib/LWP.pm',
     ABSTRACT => 'The World-Wide Web library for Perl',
     AUTHOR => 'Gisle Aas <gisle@activestate.com>',


### PR DESCRIPTION
I using this script for checking version of all modules in perl installation.
---------------------------------------------------------------------------------------------

#!/bin/sh

mod=$1
if test "x$PERL" = "x"; then
   PERL=perl
fi
perl -MExtUtils::Installed -e '$inst = ExtUtils::Installed->new(); @modules = $inst->modules(); print join("\n", @modules);' |while read mod; do
print $mod
$PERL -M$mod -e "print \"$mod: \$$mod::VERSION\n\""
done

---------------------------------------------------------------------------------------------
Obviously, for your module, the $mod is 'libwww-perl' and $$mod::VERSION gives an error:
Can't locate libwww.pm in @INC (@INC contains: ....).