### PR TITLE
Add HTML::Form dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,7 @@ my %WriteMakefileArgs = (
         'Encode::Locale' => 0,
         'File::Listing' => 6,
         'HTML::Entities' => 0,
+        'HTML::Form' => 6,
         'HTML::HeadParser' => 0,
         'HTTP::Cookies' => 6,
         'HTTP::Daemon' => 6,


### PR DESCRIPTION
Although HTML::Form isn't used for running the test suite (as was
the rationale for adding a dependency on HTTP::Daemon), we should add a
dependency on HTML::Form for the sake of backwards compatability (which
was the other rationale for the dependency on HTTP::Daemon).