### PR TITLE
Update timeouts on cached connections

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -623,7 +623,21 @@ sub get_basic_credentials
 }
 
 
-sub timeout      { shift->_elem('timeout',      @_); }
+sub timeout
+{
+    my $self = shift;
+    my $old = $self->{timeout};
+    if (@_) {
+        $self->{timeout} = shift;
+        if (my $conn_cache = $self->conn_cache) {
+            for my $conn ($conn_cache->get_connections) {
+                $conn->timeout($self->{timeout});
+            }
+        }
+    }
+    return $old;
+}
+
 sub local_address{ shift->_elem('local_address',@_); }
 sub max_size     { shift->_elem('max_size',     @_); }
 sub max_redirect { shift->_elem('max_redirect', @_); }
@@ -758,6 +772,11 @@ sub conn_cache {
 	    require LWP::ConnCache;
 	    $cache = LWP::ConnCache->new(%$cache);
 	}
+        else {
+            for my $conn ($cache->get_connections) {
+                $conn->timeout($self->timeout);
+            }
+        }
 	$self->{conn_cache} = $cache;
     }
     $old;


### PR DESCRIPTION
Problem
-----------

If I do this
```
$ua->conn_cache($conn_cache);
$ua->timeout(1)
$ua->get($url);
# one connection is now cached.  the cached connection has a timeout of 1
$ua->timeout(6);
$ua->get($url); 
```

The second `get()` will timeout after 1 second when it should wait 6 seconds before timing out.

Solution
----------
My solution is to change `$ua->timeout` and `$ua->conn_cache` to loop through all the connections in `$conn_cache` and update the timeouts like this:
```
for my $conn ($conn_cache->get_connections) {
    $conn->timeout($new_timeout);
}
```
