### PR TITLE
FIX: continue challenge schemes

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -392,8 +392,10 @@ sub request
 				  "Unsupported authentication scheme '$scheme'");
 		next CHALLENGE;
 	    }
-	    return $class->authenticate($self, $proxy, $challenge, $response,
+	    my $re = $class->authenticate($self, $proxy, $challenge, $response,
 					$request, $arg, $size);
+		next CHALLENGE if ($re->code == 401);
+		return $re;
 	}
 	return $response;
     }


### PR DESCRIPTION
When several challenge scheme is supported by web server (Negotiate and Basic for example)
continue trying next scheme if previous one was failed.
