### PR TITLE
Remove indirect object notation from the test suite

### DIFF
--- a/t/local/autoload-get.t
+++ b/t/local/autoload-get.t
@@ -12,7 +12,7 @@ $url = "file:.";
 require URI;
 print "Trying to fetch '" . URI->new($url)->file . "'\n";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 $ua->timeout(30);               # timeout in seconds
 
 my $response = $ua->get($url);

--- a/t/local/autoload.t
+++ b/t/local/autoload.t
@@ -13,7 +13,7 @@ $url = "file:.";
 require URI;
 print "Trying to fetch '" . URI->new($url)->file . "'\n";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 $ua->timeout(30);               # timeout in seconds
 
 my $request = HTTP::Request->new(GET => $url);

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -68,13 +68,13 @@ print "Will access HTTP server at $base\n";
 
 require LWP::UserAgent;
 require HTTP::Request;
-$ua = new LWP::UserAgent;
+$ua = LWP::UserAgent->new;
 $ua->agent("Mozilla/0.01 " . $ua->agent);
 $ua->from('gisle@aas.no');
 
 #----------------------------------------------------------------
 print "Bad request...\n";
-$req = new HTTP::Request GET => url("/not_found", $base);
+$req = HTTP::Request->new(GET => url("/not_found", $base));
 $req->header(X_Foo => "Bar");
 $res = $ua->request($req);
 
@@ -96,7 +96,7 @@ sub httpd_get_echo
     print $c $req->as_string;
 }
 
-$req = new HTTP::Request GET => url("/echo/path_info?query", $base);
+$req = HTTP::Request->new(GET => url("/echo/path_info?query", $base));
 $req->push_header(Accept => 'text/html');
 $req->push_header(Accept => 'text/plain; q=0.9');
 $req->push_header(Accept => 'image/*');
@@ -206,7 +206,7 @@ sub httpd_get_file
     unlink($file) if $file =~ /^test-/;
 }
 
-$req = new HTTP::Request GET => url("/file?name=$file", $base);
+$req = HTTP::Request->new(GET => url("/file?name=$file", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 
@@ -223,7 +223,7 @@ ok($res->is_error);
 is($res->code, 404, 'response code 404');   # not found
 
 # Then try to list current directory
-$req = new HTTP::Request GET => url("/file?name=.", $base);
+$req = HTTP::Request->new(GET => url("/file?name=.", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 is($res->code, 501, 'response code 501');   # NYI
@@ -237,7 +237,7 @@ sub httpd_get_redirect
    $c->send_redirect("/echo/redirect");
 }
 
-$req = new HTTP::Request GET => url("/redirect/foo", $base);
+$req = HTTP::Request->new(GET => url("/redirect/foo", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 
@@ -297,7 +297,7 @@ sub httpd_get_basic
       }
    }
 }
-$req = new HTTP::Request GET => url("/basic", $base);
+$req = HTTP::Request->new(GET => url("/basic", $base));
 $res = MyUA->new->request($req);
 #print $res->as_string;
 
@@ -366,7 +366,7 @@ sub httpd_get_digest
 		}
 	}
 }
-$req = new HTTP::Request GET => url("/digest", $base);
+$req = HTTP::Request->new(GET => url("/digest", $base));
 $res = MyUA2->new->request($req);
 #print STDERR $res->as_string;
 
@@ -407,7 +407,7 @@ sub httpd_get_proxy
 }
 
 $ua->proxy(ftp => $base);
-$req = new HTTP::Request GET => "ftp://ftp.perl.com/proxy";
+$req = HTTP::Request->new(GET => "ftp://ftp.perl.com/proxy");
 $res = $ua->request($req);
 #print $res->as_string;
 ok($res->is_success);
@@ -433,7 +433,7 @@ sub httpd_post_echo
    unlink("tmp$$");
 }
 
-$req = new HTTP::Request POST => url("/echo/foo", $base);
+$req = HTTP::Request->new(POST => url("/echo/foo", $base));
 $req->content_type("application/x-www-form-urlencoded");
 $req->content("foo=bar&bar=test");
 $res = $ua->request($req);
@@ -491,7 +491,7 @@ sub httpd_get_quit
     exit;  # terminate HTTP server
 }
 
-$req = new HTTP::Request GET => url("/quit", $base);
+$req = HTTP::Request->new(GET => url("/quit", $base));
 $res = $ua->request($req);
 
 is($res->code, 503, 'response code is 503');

--- a/t/misc/dbmrobot
+++ b/t/misc/dbmrobot
@@ -8,16 +8,14 @@ require LWP::RobotUA;
 
 $botname = "Spider/0.1";
 
-$rules = new WWW::RobotRules::AnyDBM_File $botname, 'robotdb';
-$ua = new LWP::RobotUA $botname, 'gisle@aas.no', $rules;
+$rules = WWW::RobotRules::AnyDBM_File->new($botname, 'robotdb');
+$ua = LWP::RobotUA->new($botname, 'gisle@aas.no', $rules);
 $ua->delay(0.1);
 
-my $req = new HTTP::Request GET => $url;
+my $req = HTTP::Request->new(GET => $url);
 
 my $res = $ua->request($req);
 print "Got ", $res->code, " ", $res->message, "(", $res->content_type, ")\n";
 
 my $netloc = $url->netloc;
 print "This was visit no ", $ua->no_visits($netloc), " to $netloc\n";
-
-

--- a/t/misc/get-callback
+++ b/t/misc/get-callback
@@ -4,7 +4,7 @@ $url = "http://localhost:8080/$url" unless $url =~ /:/;
 
 use LWP::UserAgent;
 
-$ua = new LWP::UserAgent;
+$ua = LWP::UserAgent->new;
 
 
 $tot = 0;

--- a/t/misc/get-file
+++ b/t/misc/get-file
@@ -6,7 +6,7 @@ $to = "index.html" unless length $to;
 
 use LWP::UserAgent;
 
-$ua = new LWP::UserAgent;
+$ua = LWP::UserAgent->new;
 #$ua->agent("get-file/0.1");
 #$ua->from('aas@sn.no');
 

--- a/t/net/http-get.t
+++ b/t/net/http-get.t
@@ -15,14 +15,14 @@ require LWP::UserAgent;
 
 print "1..2\n";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 
 $netloc = $net::httpserver;
 $script = $net::cgidir . "/test";
 
 $url = "http://$netloc$script?query";
 
-my $request = new HTTP::Request('GET', $url);
+my $request = HTTP::Request->new('GET', $url);
 
 print "GET $url\n\n";
 

--- a/t/net/http-post.t
+++ b/t/net/http-post.t
@@ -18,13 +18,13 @@ print "1..2\n";
 $netloc = $net::httpserver;
 $script = $net::cgidir . "/test";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 
 $url = "http://$netloc$script";
 
 my $form = 'searchtype=Substring';
 
-my $request = new HTTP::Request('POST', $url, undef, $form);
+my $request = HTTP::Request->new('POST', $url, undef, $form);
 $request->header('Content-Type', 'application/x-www-form-urlencoded');
 
 my $response = $ua->request($request, undef, undef);

--- a/t/net/http-timeout.t
+++ b/t/net/http-timeout.t
@@ -14,7 +14,7 @@ require LWP::UserAgent;
 
 print "1..1\n";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 
 $ua->timeout(4);
 
@@ -23,7 +23,7 @@ $script = $net::cgidir . "/timeout";
 
 $url = "http://$netloc$script";
 
-my $request = new HTTP::Request('GET', $url);
+my $request = HTTP::Request->new('GET', $url);
 
 print $request->as_string;
 

--- a/t/net/mirror.t
+++ b/t/net/mirror.t
@@ -14,7 +14,7 @@ require HTTP::Status;
 
 print "1..2\n";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 
 my $url = "http://$net::httpserver/";
 my $copy = "lwp-test-$$"; # downloaded copy

--- a/t/net/moved.t
+++ b/t/net/moved.t
@@ -14,10 +14,10 @@ print "1..1\n";
 
 $url = "http://$net::httpserver$net::cgidir/moved";
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 $ua->timeout(30);               # timeout in seconds
 
-my $request = new HTTP::Request('GET', $url);
+my $request = HTTP::Request->new('GET', $url);
 
 print $request->as_string;
 

--- a/t/net/proxy.t
+++ b/t/net/proxy.t
@@ -22,13 +22,13 @@ unless (defined $net::ftp_proxy) {
 require HTTP::Request;
 require LWP::UserAgent;
 
-my $ua = new LWP::UserAgent;    # create a useragent to test
+my $ua = LWP::UserAgent->new;   # create a useragent to test
 
 $ua->proxy('ftp', $net::ftp_proxy);
 
 my $url = 'ftp://ftp.uninett.no/';
 
-my $request = new HTTP::Request('GET', $url);
+my $request = HTTP::Request->new('GET', $url);
 
 my $response = $ua->request($request, undef, undef);
 

--- a/t/robot/ua-get.t
+++ b/t/robot/ua-get.t
@@ -69,7 +69,7 @@ print "Will access HTTP server at $base\n";
 
 require LWP::RobotUA;
 require HTTP::Request;
-$ua = new LWP::RobotUA 'lwp-spider/0.1', 'gisle@aas.no';
+$ua = LWP::RobotUA->new('lwp-spider/0.1', 'gisle@aas.no');
 $ua->delay(0.05);  # rather quick robot
 
 #----------------------------------------------------------------
@@ -146,7 +146,7 @@ $ua->delay(1);
 print "not " unless abs($ua->host_wait($base->host_port) - 60) < 5;
 print "ok 6\n";
 
-# Number of visits to this place should be 
+# Number of visits to this place should be
 print "not " unless $ua->no_visits($base->host_port) == 4;
 print "ok 7\n";
 

--- a/t/robot/ua.t
+++ b/t/robot/ua.t
@@ -69,7 +69,7 @@ print "Will access HTTP server at $base\n";
 
 require LWP::RobotUA;
 require HTTP::Request;
-$ua = new LWP::RobotUA 'lwp-spider/0.1', 'gisle@aas.no';
+$ua = LWP::RobotUA->new('lwp-spider/0.1', 'gisle@aas.no');
 $ua->delay(0.05);  # rather quick robot
 
 #----------------------------------------------------------------
@@ -96,20 +96,20 @@ sub httpd_get_someplace
    $c->print("Okidok\n");
 }
 
-$req = new HTTP::Request GET => url("/someplace", $base);
+$req = HTTP::Request->new(GET => url("/someplace", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 print "not " unless $res->is_success;
 print "ok 1\n";
 
-$req = new HTTP::Request GET => url("/private/place", $base);
+$req = HTTP::Request->new(GET => url("/private/place", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 print "not " unless $res->code == 403
                 and $res->message =~ /robots.txt/;
 print "ok 2\n";
 
-$req = new HTTP::Request GET => url("/foo", $base);
+$req = HTTP::Request->new(GET => url("/foo", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 print "not " unless $res->code == 404;  # not found
@@ -118,7 +118,7 @@ print "ok 3\n";
 # Let the robotua generate "Service unavailable/Retry After response";
 $ua->delay(1);
 $ua->use_sleep(0);
-$req = new HTTP::Request GET => url("/foo", $base);
+$req = HTTP::Request->new(GET => url("/foo", $base));
 $res = $ua->request($req);
 #print $res->as_string;
 print "not " unless $res->code == 503   # Unavailable
@@ -135,7 +135,7 @@ sub httpd_get_quit
 }
 
 $ua->delay(0);
-$req = new HTTP::Request GET => url("/quit", $base);
+$req = HTTP::Request->new(GET => url("/quit", $base));
 $res = $ua->request($req);
 
 print "not " unless $res->code == 503 and $res->content =~ /Bye, bye/;
@@ -148,7 +148,6 @@ $ua->delay(1);
 print "not " unless abs($ua->host_wait($base->host_port) - 60) < 5;
 print "ok 6\n";
 
-# Number of visits to this place should be 
+# Number of visits to this place should be
 print "not " unless $ua->no_visits($base->host_port) == 4;
 print "ok 7\n";
-


### PR DESCRIPTION
The test suite had lots of indirect object notation usage.  This is a simple pull request to fix that.

Thanks,
Chase