### PR TITLE
Encourage the use of HTTP::CookieJar::LWP

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,6 +16,7 @@ on 'runtime' => sub {
     requires 'HTML::Entities';
     requires 'HTML::HeadParser';
     requires 'HTTP::Cookies' => '6';
+    requires 'HTTP::CookieJar::LWP';
     requires 'HTTP::Daemon' => '6';
     requires 'HTTP::Date' => '6';
     requires 'HTTP::Negotiate' => '6';

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -757,6 +757,10 @@ sub cookie_jar {
 	    require HTTP::Cookies;
 	    $jar = HTTP::Cookies->new(%$jar);
 	}
+        elsif (ref($jar) eq "ARRAY") {
+            require HTTP::CookieJar::LWP;
+            $jar = HTTP::CookieJar::LWP->new(@$jar);
+        }
 	$self->{cookie_jar} = $jar;
         $self->set_my_handler("request_prepare",
             $jar ? sub { $jar->add_cookie_header($_[0]); } : undef,
@@ -1267,15 +1271,20 @@ Get/set the cookie jar object to use.  The only requirement is that
 the cookie jar object must implement the C<extract_cookies($response)> and
 C<add_cookie_header($request)> methods.  These methods will then be
 invoked by the user agent as requests are sent and responses are
-received.  Normally this will be a L<HTTP::Cookies> object or some
-subclass.
+received.
 
 The default is to have no cookie jar, i.e. never automatically add
 C<Cookie> headers to the requests.
 
-Shortcut: If a reference to a plain hash is passed in, it is replaced with an
-instance of L<HTTP::Cookies> that is initialized based on the hash. This form
-also automatically loads the L<HTTP::Cookies> module.  It means that:
+Examples of suitable cookie jar objects include L<HTTP::Cookies> and
+L<HTTP::CookieJar::LWP>.  C<HTTP::CookieJar::LWP> provides a better
+security model matching that of current Web browsers when
+L<Mozilla::PublicSuffix> is installed.
+
+If C<$cookie_jar_obj> contains an unblessed array reference, its
+contents are passed as arguments to to C<HTTP::CookieJar::LWP->new>.  An
+unblessed hash reference has its contents passed to
+C<HTTP::Cookies->new>.  So:
 
   $ua->cookie_jar({ file => "$ENV{HOME}/.cookies.txt" });
 

--- a/t/local/cookie_jar.t
+++ b/t/local/cookie_jar.t
@@ -1,0 +1,16 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use_ok 'LWP::UserAgent';
+
+my $ua = LWP::UserAgent->new( cookie_jar => {} );
+isa_ok $ua->cookie_jar, 'HTTP::Cookies';
+
+$ua = LWP::UserAgent->new( cookie_jar => [] );
+isa_ok $ua->cookie_jar, 'HTTP::CookieJar::LWP';
+
+done_testing();


### PR DESCRIPTION
HTTP::CookieJar::LWP supports https://publicsuffix.org/ whereas
HTTP::Cookies does not.
