### PR TITLE
Fix bug with LWP::Authen::Digest not reauthenticating stale nonces

### DIFF
--- a/lib/LWP/Authen/Basic.pm
+++ b/lib/LWP/Authen/Basic.pm
@@ -46,9 +46,10 @@ sub authenticate
 	return $response;
     }
 
-    # check that the password has changed
+    # check that the password or nonce has changed
     my ($olduser, $oldpass) = $ua->credentials($host_port, $realm);
-    return $response if (defined $olduser and defined $oldpass and
+    return $response if (!$auth_param->{stale} and 
+                         defined $olduser and defined $oldpass and
                          $user eq $olduser and $pass eq $oldpass);
 
     $ua->credentials($host_port, $realm, $user, $pass);


### PR DESCRIPTION
(This bug is described in CPAN RT as well: https://rt.cpan.org/Ticket/Display.html?id=75908)

HTTP Servers are allowed to expire Digest authentication requests after an arbitrary time has passed. In this case, the server returns a 401 response code with a `WWW-Authenticate:` header containing a new nonce and `stale=true`.  The expectation is that the client will resubmit a recalculated authentication digest using the same username and password used previously, but the new nonce provided by the server.

LWP does not conform to this expected behavior. As a result, any LWP::UserAgent using Digest authentication is subject to failing at any moment if a server decides that Digest authentication has expired.

LWP handles repeating authentication requests in `LWP::Authen::Basic::authenticate`, but it refuses to resubmit a request with new authentication information unless the username or password has changed.  The patch provided in this pull request modifies `LWP::Authen::Basic:authenticate` to also resubmit the request if `stale=true` was present on the `WWW-Authenticate:` header. 

I have added a test in `t/local/http.t` to reflect this new behavior.

One potential concern with this patch is that it fixes the behavior of `LWP::Authen::Digest`, but the change itself is made within LWP::Authen::Basic. To avoid this misplaced code without incorporating all of`sub authenticate` into LWP::Authen::Digest, I would recommend factoring out a "should_reauthenticate" method that is used to decide whether to resubmit the request, and is implemented differently in Basic.pm and Digest.pm.  I would be happy to make that change, if it is preferred over the current change set.

Thanks for your continued work supporting this mission critical module!
