### PR TITLE
Let default_header(Content-Type => '...') work for post/put

### DIFF
--- a/t/base/default_content_type.t
+++ b/t/base/default_content_type.t
@@ -1,0 +1,67 @@
+use strict;
+use warnings;
+use Test::More;
+
+use LWP::UserAgent;
+plan tests => 10;
+
+# Prevent environment from interfering with test:
+delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
+delete $ENV{HTTPS_CA_FILE};
+delete $ENV{HTTPS_CA_DIR};
+delete $ENV{PERL_LWP_SSL_CA_FILE};
+delete $ENV{PERL_LWP_SSL_CA_PATH};
+delete $ENV{PERL_LWP_ENV_PROXY};
+
+my $ua = LWP::UserAgent->new;
+
+# default_header 'Content-Type' should be honored in POST/PUT
+# if the "Content => 'string'" form is used. Otherwise, x-www-form-urlencoded
+# will be used
+
+$ua->default_header('Content-Type' => 'application/json');
+
+$ua->proxy(http => "loopback:");
+$ua->agent("foo/0.1");
+
+my $url = "http://www.example.com";
+
+# These forms will all be x-www-form-urlencoded
+for my $call (qw(post put)) {
+    for my $arg (
+        [ { cat => 'dog' }             ],
+        [ [ cat => 'dog' ]             ],
+        [ Content => { cat => 'dog' }, ],
+        [ Content => [ cat => 'dog' ], ],
+    ) {
+        my $ucall = uc $call;
+
+        is ($ua->$call($url, @$arg)->content, <<"EOT", "$call @$arg");
+$ucall http://www.example.com
+User-Agent: foo/0.1
+Content-Length: 7
+Content-Type: application/x-www-form-urlencoded
+
+cat=dog
+EOT
+
+    }
+}
+
+# These should all use the default
+for my $call (qw(post put)) {
+    my $ucall = uc $call;
+
+    my $arg = [ Content => '{"cat":"dog"}' ];
+
+    is ($ua->$call($url, @$arg)->content, <<"EOT", "$call @$arg");
+$ucall http://www.example.com
+User-Agent: foo/0.1
+Content-Length: 13
+Content-Type: application/json
+
+{"cat":"dog"}
+EOT
+
+}
+


### PR DESCRIPTION
If you say:

    $ua->default_header('Content-Type' => 'foo');
    $ua->post($url, Content => 'string');

You very likely mean for the request to use the provided
default Content-Type (in this case: 'foo').

This change allows that to happen, while still letting the
following forms override the default Content-Type with
'x-www-form-urlencoded' (since that makes sense as the body
of the request is being encoded for you):

    $ua->post($url, \%form);
    $ua->post($url, \@form);
    $ua->post($url, Content => \%form);
    $ua->post($url, Content => \@form);