### PR TITLE
Eval -> Try::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,6 +68,7 @@ my %WriteMakefileArgs = (
         'MIME::Base64' => "2.1",
         'Net::FTP' => "2.58",
         'Net::HTTP' => "6.07",
+        'Scalar::Util' => 0,
         'URI' => "1.10",
         'URI::Escape' => 0,
         'WWW::RobotRules' => 6,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -69,6 +69,7 @@ my %WriteMakefileArgs = (
         'Net::FTP' => "2.58",
         'Net::HTTP' => "6.07",
         'Scalar::Util' => 0,
+        'Try::Tiny' => 0,
         'URI' => "1.10",
         'URI::Escape' => 0,
         'WWW::RobotRules' => 6,


### PR DESCRIPTION
Update all of the places where we had a raw ```eval``` and replace it with a ```try {} catch {};``` block.

There was also a ```UNIVERSAL::isa()``` call that got switched to ```->isa()``` instead.  These changes require adding two prerequisites, ```Scalar::Util``` and ```Try::Tiny```.

While the changes test properly, they did require a few changes to the loading of protocol packages.

A full review by a few is needed.
