### PR TITLE
Fix incorrect usage of Try::Tiny

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -267,14 +267,18 @@ sub simple_request
         Carp::croak("No request object passed in");
     }
 
+    my $error;
     try {
         $request = $self->prepare_request($request);
     }
     catch {
-        my $error = $_;
+        $error = $_;
         $error =~ s/ at .* line \d+.*//s;  # remove file/line number
-        return _new_response($request, &HTTP::Status::RC_BAD_REQUEST, $error);
     };
+
+    if ($error) {
+        return _new_response($request, &HTTP::Status::RC_BAD_REQUEST, $error);
+    }
     return $self->send_request($request, $arg, $size);
 }
 


### PR DESCRIPTION
As was pointed out in Issue #107 an error was introduced with moving from raw ```eval```s to ```Try::Tiny``` within ```LWP::UserAgent->simple_request```.

This fix should accurately trap the errors and return the error response when found.  Also, a few new tests were added to ```t/base/ua.t``` to test the ways in which the call to ```->prepare_request``` can die from within ```->simple_request```.

