### PR TITLE
Clean up the request method and fix the "next" call within the catch

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -283,16 +283,16 @@ sub simple_request
 }
 
 
-sub request
-{
-    my($self, $request, $arg, $size, $previous) = @_;
+sub request {
+    my ($self, $request, $arg, $size, $previous) = @_;
 
     my $response = $self->simple_request($request, $arg, $size);
     $response->previous($previous) if $previous;
 
     if ($response->redirects >= $self->{max_redirect}) {
         $response->header("Client-Warning" =>
-                          "Redirect loop detected (max_redirect = $self->{max_redirect})");
+                "Redirect loop detected (max_redirect = $self->{max_redirect})"
+        );
         return $response;
     }
 
@@ -302,117 +302,120 @@ sub request
 
     my $code = $response->code;
 
-    if ($code == &HTTP::Status::RC_MOVED_PERMANENTLY or
-	$code == &HTTP::Status::RC_FOUND or
-	$code == &HTTP::Status::RC_SEE_OTHER or
-	$code == &HTTP::Status::RC_TEMPORARY_REDIRECT)
+    if (   $code == &HTTP::Status::RC_MOVED_PERMANENTLY
+        or $code == &HTTP::Status::RC_FOUND
+        or $code == &HTTP::Status::RC_SEE_OTHER
+        or $code == &HTTP::Status::RC_TEMPORARY_REDIRECT)
     {
-	my $referral = $request->clone;
+        my $referral = $request->clone;
 
-	# These headers should never be forwarded
-	$referral->remove_header('Host', 'Cookie');
+        # These headers should never be forwarded
+        $referral->remove_header('Host', 'Cookie');
 
-	if ($referral->header('Referer') &&
-	    $request->uri->scheme eq 'https' &&
-	    $referral->uri->scheme eq 'http')
-	{
-	    # RFC 2616, section 15.1.3.
-	    # https -> http redirect, suppressing Referer
-	    $referral->remove_header('Referer');
-	}
-
-	if ($code == &HTTP::Status::RC_SEE_OTHER ||
-	    $code == &HTTP::Status::RC_FOUND)
+        if (   $referral->header('Referer')
+            && $request->uri->scheme eq 'https'
+            && $referral->uri->scheme eq 'http')
         {
-	    my $method = uc($referral->method);
-	    unless ($method eq "GET" || $method eq "HEAD") {
-		$referral->method("GET");
-		$referral->content("");
-		$referral->remove_content_headers;
-	    }
-	}
+            # RFC 2616, section 15.1.3.
+            # https -> http redirect, suppressing Referer
+            $referral->remove_header('Referer');
+        }
 
-	# And then we update the URL based on the Location:-header.
-	my $referral_uri = $response->header('Location');
-	{
-	    # Some servers erroneously return a relative URL for redirects,
-	    # so make it absolute if it not already is.
-	    local $URI::ABS_ALLOW_RELATIVE_SCHEME = 1;
-	    my $base = $response->base;
-	    $referral_uri = "" unless defined $referral_uri;
-	    $referral_uri = $HTTP::URI_CLASS->new($referral_uri, $base)
-		            ->abs($base);
-	}
-	$referral->uri($referral_uri);
+        if (   $code == &HTTP::Status::RC_SEE_OTHER
+            || $code == &HTTP::Status::RC_FOUND)
+        {
+            my $method = uc($referral->method);
+            unless ($method eq "GET" || $method eq "HEAD") {
+                $referral->method("GET");
+                $referral->content("");
+                $referral->remove_content_headers;
+            }
+        }
 
-	return $response unless $self->redirect_ok($referral, $response);
-	return $self->request($referral, $arg, $size, $response);
+        # And then we update the URL based on the Location:-header.
+        my $referral_uri = $response->header('Location');
+        {
+            # Some servers erroneously return a relative URL for redirects,
+            # so make it absolute if it not already is.
+            local $URI::ABS_ALLOW_RELATIVE_SCHEME = 1;
+            my $base = $response->base;
+            $referral_uri = "" unless defined $referral_uri;
+            $referral_uri
+                = $HTTP::URI_CLASS->new($referral_uri, $base)->abs($base);
+        }
+        $referral->uri($referral_uri);
+
+        return $response unless $self->redirect_ok($referral, $response);
+        return $self->request($referral, $arg, $size, $response);
 
     }
-    elsif ($code == &HTTP::Status::RC_UNAUTHORIZED ||
-	     $code == &HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED
-	    )
+    elsif ($code == &HTTP::Status::RC_UNAUTHORIZED
+        || $code == &HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED)
     {
-	my $proxy = ($code == &HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED);
-	my $ch_header = $proxy || $request->method eq 'CONNECT'
-	    ?  "Proxy-Authenticate" : "WWW-Authenticate";
-	my @challenge = $response->header($ch_header);
-	unless (@challenge) {
-	    $response->header("Client-Warning" =>
-			      "Missing Authenticate header");
-	    return $response;
-	}
-
-	require HTTP::Headers::Util;
-	CHALLENGE: for my $challenge (@challenge) {
-	    $challenge =~ tr/,/;/;  # "," is used to separate auth-params!!
-	    ($challenge) = HTTP::Headers::Util::split_header_words($challenge);
-	    my $scheme = shift(@$challenge);
-	    shift(@$challenge); # no value
-	    $challenge = { @$challenge };  # make rest into a hash
-
-	    unless ($scheme =~ /^([a-z]+(?:-[a-z]+)*)$/) {
-		$response->header("Client-Warning" =>
-				  "Bad authentication scheme '$scheme'");
-		return $response;
-	    }
-	    $scheme = $1;  # untainted now
-	    my $class = "LWP::Authen::\u$scheme";
-	    $class =~ s/-/_/g;
-
-	    no strict 'refs';
-	    unless (%{"$class\::"}) {
-		# try to load it
-        try {
-            (my $req = $class) =~ s{::}{/}g;
-            $req .= '.pm' unless $req =~ /\.pm$/;
-            require $req;
+        my $proxy = ($code == &HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED);
+        my $ch_header
+            = $proxy || $request->method eq 'CONNECT'
+            ? "Proxy-Authenticate"
+            : "WWW-Authenticate";
+        my @challenges = $response->header($ch_header);
+        unless (@challenges) {
+            $response->header(
+                "Client-Warning" => "Missing Authenticate header");
+            return $response;
         }
-        catch {
-            my $error = $_;
-		    if ($error =~ /^Can\'t locate/) {
-			$response->header("Client-Warning" =>
-					  "Unsupported authentication scheme '$scheme'");
-		    }
-		    else {
-			$response->header("Client-Warning" => $error);
-		    }
-		    next CHALLENGE;
-		};
-	    }
-	    unless ($class->can("authenticate")) {
-		$response->header("Client-Warning" =>
-				  "Unsupported authentication scheme '$scheme'");
-		next CHALLENGE;
-	    }
-	    return $class->authenticate($self, $proxy, $challenge, $response,
-					$request, $arg, $size);
-	}
-	return $response;
+
+        require HTTP::Headers::Util;
+        CHALLENGE: for my $challenge (@challenges) {
+            $challenge =~ tr/,/;/;    # "," is used to separate auth-params!!
+            ($challenge) = HTTP::Headers::Util::split_header_words($challenge);
+            my $scheme = shift(@$challenge);
+            shift(@$challenge);       # no value
+            $challenge = {@$challenge};    # make rest into a hash
+
+            unless ($scheme =~ /^([a-z]+(?:-[a-z]+)*)$/) {
+                $response->header(
+                    "Client-Warning" => "Bad authentication scheme '$scheme'");
+                return $response;
+            }
+            $scheme = $1;                  # untainted now
+            my $class = "LWP::Authen::\u$scheme";
+            $class =~ s/-/_/g;
+
+            no strict 'refs';
+            unless (%{"$class\::"}) {
+                # try to load it
+                my $error;
+                try {
+                    (my $req = $class) =~ s{::}{/}g;
+                    $req .= '.pm' unless $req =~ /\.pm$/;
+                    require $req;
+                }
+                catch {
+                    $error = $_;
+                };
+                if ($error) {
+                    if ($error =~ /^Can\'t locate/) {
+                        $response->header("Client-Warning" =>
+                                "Unsupported authentication scheme '$scheme'");
+                    }
+                    else {
+                        $response->header("Client-Warning" => $error);
+                    }
+                    next CHALLENGE;
+                }
+            }
+            unless ($class->can("authenticate")) {
+                $response->header("Client-Warning" =>
+                        "Unsupported authentication scheme '$scheme'");
+                next CHALLENGE;
+            }
+            return $class->authenticate($self, $proxy, $challenge, $response,
+                $request, $arg, $size);
+        }
+        return $response;
     }
     return $response;
 }
-
 
 #
 # Now the shortcuts...


### PR DESCRIPTION
When making use of Try::Tiny, a few bugs were introduced. This PR should remove the last potential bug where within the ```catch``` block there was a ```next CHALLENGE```.