### PR TITLE
Make calls to constant HTTP::Status functions no longer use &FUNC form

### DIFF
--- a/lib/LWP/Protocol/cpan.pm
+++ b/lib/LWP/Protocol/cpan.pm
@@ -49,14 +49,14 @@ sub request {
     # check proxy
     if (defined $proxy)
     {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   'You can not proxy with cpan');
     }
 
     # check method
     my $method = $request->method;
     unless ($method eq 'GET' || $method eq 'HEAD') {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   'Library does not allow method ' .
 				   "$method for 'cpan:' URLs");
     }
@@ -64,7 +64,7 @@ sub request {
     my $path = $request->uri->path;
     $path =~ s,^/,,;
 
-    my $response = HTTP::Response->new(&HTTP::Status::RC_FOUND);
+    my $response = HTTP::Response->new(HTTP::Status::RC_FOUND);
     $response->header("Location" => URI->new_abs($path, $CPAN));
     $response;
 }

--- a/lib/LWP/Protocol/data.pm
+++ b/lib/LWP/Protocol/data.pm
@@ -21,20 +21,20 @@ sub request
     # check proxy
     if (defined $proxy)
     {
-	return HTTP::Response->new( &HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new( HTTP::Status::RC_BAD_REQUEST,
 				  'You can not proxy with data');
     }
 
     # check method
     my $method = $request->method;
     unless ($method eq 'GET' || $method eq 'HEAD') {
-	return HTTP::Response->new( &HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new( HTTP::Status::RC_BAD_REQUEST,
 				  'Library does not allow method ' .
 				  "$method for 'data:' URLs");
     }
 
     my $url = $request->uri;
-    my $response = HTTP::Response->new( &HTTP::Status::RC_OK, "Document follows");
+    my $response = HTTP::Response->new( HTTP::Status::RC_OK, "Document follows");
 
     my $media_type = $url->media_type;
 

--- a/lib/LWP/Protocol/file.pm
+++ b/lib/LWP/Protocol/file.pm
@@ -21,14 +21,14 @@ sub request
     # check proxy
     if (defined $proxy)
     {
-	return HTTP::Response->new( &HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new( HTTP::Status::RC_BAD_REQUEST,
 				  'You can not proxy through the filesystem');
     }
 
     # check method
     my $method = $request->method;
     unless ($method eq 'GET' || $method eq 'HEAD') {
-	return HTTP::Response->new( &HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new( HTTP::Status::RC_BAD_REQUEST,
 				  'Library does not allow method ' .
 				  "$method for 'file:' URLs");
     }
@@ -38,7 +38,7 @@ sub request
 
     my $scheme = $url->scheme;
     if ($scheme ne 'file') {
-	return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 			   "LWP::Protocol::file::request called for '$scheme'");
     }
 
@@ -47,11 +47,11 @@ sub request
 
     # test file exists and is readable
     unless (-e $path) {
-	return HTTP::Response->new( &HTTP::Status::RC_NOT_FOUND,
+	return HTTP::Response->new( HTTP::Status::RC_NOT_FOUND,
 				  "File `$path' does not exist");
     }
     unless (-r _) {
-	return HTTP::Response->new( &HTTP::Status::RC_FORBIDDEN,
+	return HTTP::Response->new( HTTP::Status::RC_FORBIDDEN,
 				  'User does not have read permission');
     }
 
@@ -67,13 +67,13 @@ sub request
     if (defined $ims) {
 	my $time = HTTP::Date::str2time($ims);
 	if (defined $time and $time >= $mtime) {
-	    return HTTP::Response->new( &HTTP::Status::RC_NOT_MODIFIED,
+	    return HTTP::Response->new( HTTP::Status::RC_NOT_MODIFIED,
 				      "$method $path");
 	}
     }
 
     # Ok, should be an OK response by now...
-    my $response = HTTP::Response->new( &HTTP::Status::RC_OK );
+    my $response = HTTP::Response->new( HTTP::Status::RC_OK );
 
     # fill in response headers
     $response->header('Last-Modified', HTTP::Date::time2str($mtime));
@@ -81,7 +81,7 @@ sub request
     if (-d _) {         # If the path is a directory, process it
 	# generate the HTML for directory
 	opendir(D, $path) or
-	   return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	   return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 				     "Cannot read directory '$path': $!");
 	my(@files) = sort readdir(D);
 	closedir(D);
@@ -128,7 +128,7 @@ sub request
     # read the file
     if ($method ne "HEAD") {
 	open(F, $path) or return new
-	    HTTP::Response(&HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    HTTP::Response(HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 			   "Cannot read file '$path': $!");
 	binmode(F);
 	$response =  $self->collect($arg, $response, sub {

--- a/lib/LWP/Protocol/gopher.pm
+++ b/lib/LWP/Protocol/gopher.pm
@@ -47,7 +47,7 @@ sub request
 
     # check proxy
     if (defined $proxy) {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   'You can not proxy through the gopher');
     }
 
@@ -57,19 +57,19 @@ sub request
 
     my $method = $request->method;
     unless ($method eq 'GET' || $method eq 'HEAD') {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   'Library does not allow method ' .
 				   "$method for 'gopher:' URLs");
     }
 
     my $gophertype = $url->gopher_type;
     unless (exists $gopher2mimetype{$gophertype}) {
-	return HTTP::Response->new(&HTTP::Status::RC_NOT_IMPLEMENTED,
+	return HTTP::Response->new(HTTP::Status::RC_NOT_IMPLEMENTED,
 				   'Library does not support gophertype ' .
 				   $gophertype);
     }
 
-    my $response = HTTP::Response->new(&HTTP::Status::RC_OK, "OK");
+    my $response = HTTP::Response->new(HTTP::Status::RC_OK, "OK");
     $response->header('Content-type' => $gopher2mimetype{$gophertype}
 					|| 'text/plain');
     $response->header('Content-Encoding' => $gopher2encoding{$gophertype})
@@ -80,7 +80,7 @@ sub request
 	$response->header('Client-Warning' => 'Client answer only');
 	return $response;
     }
-    
+
     if ($gophertype eq '7' && ! $url->search) {
       # the url is the prompt for a gopher search; supply boiler-plate
       return $self->collect_once($arg, $response, <<"EOT");

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -132,7 +132,7 @@ sub request
     # check method
     my $method = $request->method;
     unless ($method =~ /^[A-Za-z0-9_!\#\$%&\'*+\-.^\`|~]+$/) {  # HTTP token
-	return HTTP::Response->new( &HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new( HTTP::Status::RC_BAD_REQUEST,
 				  'Library does not allow method ' .
 				  "$method for 'http:' URLs");
     }

--- a/lib/LWP/Protocol/mailto.pm
+++ b/lib/LWP/Protocol/mailto.pm
@@ -39,7 +39,7 @@ sub request
     # check proxy
     if (defined $proxy)
     {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				  'You can not proxy with mail');
     }
 
@@ -47,7 +47,7 @@ sub request
     my $method = $request->method;
 
     if ($method ne 'POST') {
-	return HTTP::Response->new( &HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new( HTTP::Status::RC_BAD_REQUEST,
 				  'Library does not allow method ' .
 				  "$method for 'mailto:' URLs");
     }
@@ -57,7 +57,7 @@ sub request
 
     my $scheme = $url->scheme;
     if ($scheme ne 'mailto') {
-	return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 			 "LWP::Protocol::mailto::request called for '$scheme'");
     }
     if ($^O eq "MacOS") {
@@ -65,28 +65,28 @@ sub request
 	    require Mail::Internet;
 	};
 	if($@) {
-	    return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 	               "You don't have MailTools installed");
 	}
 	unless ($ENV{SMTPHOSTS}) {
-	    return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 	               "You don't have SMTPHOSTS defined");
 	}
     }
     else {
 	unless (-x $SENDMAIL) {
-	    return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 	               "You don't have $SENDMAIL");
     }
     }
     if ($^O eq "MacOS") {
 	    $mail = Mail::Internet->new or
-	    return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 	    "Can't get a Mail::Internet object");
     }
     else {
 	open(SENDMAIL, "| $SENDMAIL -oi -t") or
-	    return HTTP::Response->new( &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new( HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 	               "Can't run $SENDMAIL: $!");
     }
     if ($^O eq "MacOS") {
@@ -151,20 +151,20 @@ sub request
     if ($^O eq "MacOS") {
 	$mail->body(\@text);
 	unless ($mail->smtpsend) {
-	    return HTTP::Response->new(&HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new(HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 				       "Mail::Internet->smtpsend unable to send message to <$addr>");
 	}
     }
     else {
 	unless (close(SENDMAIL)) {
 	    my $err = $! ? "$!" : "Exit status $?";
-	    return HTTP::Response->new(&HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	    return HTTP::Response->new(HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 				       "$SENDMAIL: $err");
 	}
     }
 
 
-    my $response = HTTP::Response->new(&HTTP::Status::RC_ACCEPTED,
+    my $response = HTTP::Response->new(HTTP::Status::RC_ACCEPTED,
 				       "Mail accepted");
     $response->header('Content-Type', 'text/plain');
     if ($^O eq "MacOS") {

--- a/lib/LWP/Protocol/nntp.pm
+++ b/lib/LWP/Protocol/nntp.pm
@@ -20,7 +20,7 @@ sub request
 
     # Check for proxy
     if (defined $proxy) {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   'You can not proxy through NNTP');
     }
 
@@ -28,14 +28,14 @@ sub request
     my $url = $request->uri;
     my $scheme = $url->scheme;
     unless ($scheme eq 'news' || $scheme eq 'nntp') {
-	return HTTP::Response->new(&HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+	return HTTP::Response->new(HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 				   "LWP::Protocol::nntp::request called for '$scheme'");
     }
 
     # check for a valid method
     my $method = $request->method;
     unless ($method eq 'GET' || $method eq 'HEAD' || $method eq 'POST') {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   'Library does not allow method ' .
 				   "$method for '$scheme:' URLs");
     }
@@ -45,7 +45,7 @@ sub request
     my $is_art = $groupart =~ /@/;
 
     if ($is_art && $method eq 'POST') {
-	return HTTP::Response->new(&HTTP::Status::RC_BAD_REQUEST,
+	return HTTP::Response->new(HTTP::Status::RC_BAD_REQUEST,
 				   "Can't post to an article <$groupart>");
     }
 
@@ -58,10 +58,10 @@ sub request
 
     # Check the initial welcome message from the NNTP server
     if ($nntp->status != 2) {
-	return HTTP::Response->new(&HTTP::Status::RC_SERVICE_UNAVAILABLE,
+	return HTTP::Response->new(HTTP::Status::RC_SERVICE_UNAVAILABLE,
 				   $nntp->message);
     }
-    my $response = HTTP::Response->new(&HTTP::Status::RC_OK, "OK");
+    my $response = HTTP::Response->new(HTTP::Status::RC_OK, "OK");
 
     my $mess = $nntp->message;
 
@@ -75,7 +75,7 @@ sub request
     # First we handle posting of articles
     if ($method eq 'POST') {
 	$nntp->quit; $nntp = undef;
-	$response->code(&HTTP::Status::RC_NOT_IMPLEMENTED);
+	$response->code(HTTP::Status::RC_NOT_IMPLEMENTED);
 	$response->message("POST not implemented yet");
 	return $response;
     }
@@ -83,13 +83,13 @@ sub request
     # The method must be "GET" or "HEAD" by now
     if (!$is_art) {
 	if (!$nntp->group($groupart)) {
-	    $response->code(&HTTP::Status::RC_NOT_FOUND);
+	    $response->code(HTTP::Status::RC_NOT_FOUND);
 	    $response->message($nntp->message);
 	}
 	$nntp->quit; $nntp = undef;
 	# HEAD: just check if the group exists
 	if ($method eq 'GET' && $response->is_success) {
-	    $response->code(&HTTP::Status::RC_NOT_IMPLEMENTED);
+	    $response->code(HTTP::Status::RC_NOT_IMPLEMENTED);
 	    $response->message("GET newsgroup not implemented yet");
 	}
 	return $response;
@@ -100,7 +100,7 @@ sub request
     my $art = $nntp->$get("<$groupart>");
     unless ($art) {
 	$nntp->quit; $nntp = undef;
-	$response->code(&HTTP::Status::RC_NOT_FOUND);
+	$response->code(HTTP::Status::RC_NOT_FOUND);
 	$response->message($nntp->message);
 	return $response;
     }

--- a/lib/LWP/Protocol/nogo.pm
+++ b/lib/LWP/Protocol/nogo.pm
@@ -15,9 +15,9 @@ require LWP::Protocol;
 sub request {
     my($self, $request) = @_;
     my $scheme = $request->uri->scheme;
-    
+
     return HTTP::Response->new(
-      &HTTP::Status::RC_INTERNAL_SERVER_ERROR,
+      HTTP::Status::RC_INTERNAL_SERVER_ERROR,
       "Access to \'$scheme\' URIs has been disabled"
     );
 }

--- a/lib/LWP/RobotUA.pm
+++ b/lib/LWP/RobotUA.pm
@@ -143,7 +143,7 @@ sub simple_request
     # Check rules
     unless ($allowed) {
 	my $res = HTTP::Response->new(
-	  &HTTP::Status::RC_FORBIDDEN, 'Forbidden by robots.txt');
+	  HTTP::Status::RC_FORBIDDEN, 'Forbidden by robots.txt');
 	$res->request( $request ); # bind it to that request
 	return $res;
     }
@@ -157,7 +157,7 @@ sub simple_request
 	}
 	else {
 	    my $res = HTTP::Response->new(
-	      &HTTP::Status::RC_SERVICE_UNAVAILABLE, 'Please, slow down');
+	      HTTP::Status::RC_SERVICE_UNAVAILABLE, 'Please, slow down');
 	    $res->header('Retry-After', time2str(time + $wait));
 	    $res->request( $request ); # bind it to that request
 	    return $res;

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -177,7 +177,7 @@ sub send_request
             catch {
                 my $error = $_;
                 $error =~ s/ at .* line \d+.*//s;  # remove file/line number
-                $response =  _new_response($request, &HTTP::Status::RC_NOT_IMPLEMENTED, $error);
+                $response =  _new_response($request, HTTP::Status::RC_NOT_IMPLEMENTED, $error);
                 if ($scheme eq "https") {
                     $response->message($response->message . " (LWP::Protocol::https not installed)");
                     $response->content_type("text/plain");
@@ -204,7 +204,7 @@ EOT
                     my $full = $error;
                     (my $status = $error) =~ s/\n.*//s;
                     $status =~ s/ at .* line \d+.*//s;  # remove file/line number
-                    my $code = ($status =~ s/^(\d\d\d)\s+//) ? $1 : &HTTP::Status::RC_INTERNAL_SERVER_ERROR;
+                    my $code = ($status =~ s/^(\d\d\d)\s+//) ? $1 : HTTP::Status::RC_INTERNAL_SERVER_ERROR;
                     $response = _new_response($request, $code, $status, $full);
                 }
             };
@@ -277,7 +277,7 @@ sub simple_request
     };
 
     if ($error) {
-        return _new_response($request, &HTTP::Status::RC_BAD_REQUEST, $error);
+        return _new_response($request, HTTP::Status::RC_BAD_REQUEST, $error);
     }
     return $self->send_request($request, $arg, $size);
 }
@@ -302,10 +302,10 @@ sub request {
 
     my $code = $response->code;
 
-    if (   $code == &HTTP::Status::RC_MOVED_PERMANENTLY
-        or $code == &HTTP::Status::RC_FOUND
-        or $code == &HTTP::Status::RC_SEE_OTHER
-        or $code == &HTTP::Status::RC_TEMPORARY_REDIRECT)
+    if (   $code == HTTP::Status::RC_MOVED_PERMANENTLY
+        or $code == HTTP::Status::RC_FOUND
+        or $code == HTTP::Status::RC_SEE_OTHER
+        or $code == HTTP::Status::RC_TEMPORARY_REDIRECT)
     {
         my $referral = $request->clone;
 
@@ -321,8 +321,8 @@ sub request {
             $referral->remove_header('Referer');
         }
 
-        if (   $code == &HTTP::Status::RC_SEE_OTHER
-            || $code == &HTTP::Status::RC_FOUND)
+        if (   $code == HTTP::Status::RC_SEE_OTHER
+            || $code == HTTP::Status::RC_FOUND)
         {
             my $method = uc($referral->method);
             unless ($method eq "GET" || $method eq "HEAD") {
@@ -349,10 +349,10 @@ sub request {
         return $self->request($referral, $arg, $size, $response);
 
     }
-    elsif ($code == &HTTP::Status::RC_UNAUTHORIZED
-        || $code == &HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED)
+    elsif ($code == HTTP::Status::RC_UNAUTHORIZED
+        || $code == HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED)
     {
-        my $proxy = ($code == &HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED);
+        my $proxy = ($code == HTTP::Status::RC_PROXY_AUTHENTICATION_REQUIRED);
         my $ch_header
             = $proxy || $request->method eq 'CONNECT'
             ? "Proxy-Authenticate"


### PR DESCRIPTION
Throughout the dist there are several instances where calling constant functions in the HTTP::Status dist are done via ```&func```. This could be done via ```func``` instead as there's no need to pass ```@_``` through to those functions.

This goes towards fixing #110 