### PR TITLE
remove usage of use vars pragma

### DIFF
--- a/bin/url-minder
+++ b/bin/url-minder
@@ -1,15 +1,16 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 use strict;
-use vars qw($RECEIVER %urls @mess);
-
-$RECEIVER = 'mailto:yourself@somewhere.edu';
+use warnings;
 
 use Fcntl;
 use AnyDBM_File;
 use MD5;
 use LWP;
 
+my @mess;
+my %urls;
+my $RECEIVER = 'mailto:yourself@somewhere.edu';
 tie %urls, 'AnyDBM_File', 'urls', O_CREAT|O_RDWR, 0644 or
     die "Can't open urls: $!";
 
@@ -25,7 +26,7 @@ for $url (keys %urls) {
    if ($res->is_success) {
 	my $hash = "MD5:" . MD5->hexhash($res->content);
 	if ($hash ne $urls{$url}) {
-           push(@mess, "$url changed");	
+           push(@mess, "$url changed");
 	   $urls{$url} = $hash;
         }
         else {
@@ -43,7 +44,7 @@ for $url (keys %urls) {
         }
 	print "  giving up\n";
 	push(@mess, "$url: Giving up: " . $res->message);
-        delete $urls{$url};	
+        delete $urls{$url};
    }
    else {
 	print "  bad\n";

--- a/lib/LWP/ConnCache.pm
+++ b/lib/LWP/ConnCache.pm
@@ -1,9 +1,9 @@
 package LWP::ConnCache;
 
 use strict;
-use vars qw($DEBUG);
 
 our $VERSION = '6.19';
+our $DEBUG;
 
 sub new {
     my($class, %cnf) = @_;

--- a/lib/LWP/Protocol/data.pm
+++ b/lib/LWP/Protocol/data.pm
@@ -3,13 +3,11 @@ package LWP::Protocol::data;
 # Implements access to data:-URLs as specified in RFC 2397
 
 use strict;
-use vars qw(@ISA);
 
 require HTTP::Response;
 require HTTP::Status;
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 use HTTP::Date qw(time2str);
 require LWP;  # needs version number

--- a/lib/LWP/Protocol/file.pm
+++ b/lib/LWP/Protocol/file.pm
@@ -1,7 +1,6 @@
 package LWP::Protocol::file;
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 use strict;
 

--- a/lib/LWP/Protocol/ftp.pm
+++ b/lib/LWP/Protocol/ftp.pm
@@ -11,8 +11,7 @@ use HTTP::Response ();
 use LWP::MediaTypes ();
 use File::Listing ();
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 use strict;
 eval {
@@ -21,8 +20,7 @@ eval {
     require Net::FTP;
     Net::FTP->require_version(2.00);
 
-    use vars qw(@ISA);
-    @ISA=qw(Net::FTP);
+    use base qw(Net::FTP);
 
     sub new {
 	my $class = shift;

--- a/lib/LWP/Protocol/gopher.pm
+++ b/lib/LWP/Protocol/gopher.pm
@@ -8,15 +8,13 @@ package LWP::Protocol::gopher;
 # including contributions from Marc van Heyningen and Martijn Koster.
 
 use strict;
-use vars qw(@ISA);
 
 require HTTP::Response;
 require HTTP::Status;
 require IO::Socket;
 require IO::Select;
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 
 my %gopher2mimetype = (

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -6,11 +6,9 @@ require HTTP::Response;
 require HTTP::Status;
 require Net::HTTP;
 
-use vars qw(@ISA @EXTRA_SOCK_OPTS);
+use base qw(LWP::Protocol);
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
-
+our @EXTRA_SOCK_OPTS;
 my $CRLF = "\015\012";
 
 sub _new_socket
@@ -513,7 +511,6 @@ sub increment_response_count {
 
 #-----------------------------------------------------------
 package LWP::Protocol::http::Socket;
-use vars qw(@ISA);
-@ISA = qw(LWP::Protocol::http::SocketMethods Net::HTTP);
+use base qw(LWP::Protocol::http::SocketMethods Net::HTTP);
 
 1;

--- a/lib/LWP/Protocol/loopback.pm
+++ b/lib/LWP/Protocol/loopback.pm
@@ -1,11 +1,9 @@
 package LWP::Protocol::loopback;
 
 use strict;
-use vars qw(@ISA);
 require HTTP::Response;
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 sub request {
     my($self, $request, $proxy, $arg, $size, $timeout) = @_;

--- a/lib/LWP/Protocol/mailto.pm
+++ b/lib/LWP/Protocol/mailto.pm
@@ -4,16 +4,15 @@ package LWP::Protocol::mailto;
 # frontend to the Unix sendmail program except on MacOS, where it uses
 # Mail::Internet.
 
-require LWP::Protocol;
 require HTTP::Request;
 require HTTP::Response;
 require HTTP::Status;
 
 use Carp;
 use strict;
-use vars qw(@ISA $SENDMAIL);
 
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
+our $SENDMAIL;
 
 unless ($SENDMAIL = $ENV{SENDMAIL}) {
     for my $sm (qw(/usr/sbin/sendmail

--- a/lib/LWP/Protocol/nntp.pm
+++ b/lib/LWP/Protocol/nntp.pm
@@ -2,8 +2,7 @@ package LWP::Protocol::nntp;
 
 # Implementation of the Network News Transfer Protocol (RFC 977)
 
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 require HTTP::Response;
 require HTTP::Status;

--- a/lib/LWP/Protocol/nogo.pm
+++ b/lib/LWP/Protocol/nogo.pm
@@ -6,11 +6,10 @@ package LWP::Protocol::nogo;
 # a 500 error.
 
 use strict;
-use vars qw(@ISA);
+
 require HTTP::Response;
 require HTTP::Status;
-require LWP::Protocol;
-@ISA = qw(LWP::Protocol);
+use base qw(LWP::Protocol);
 
 sub request {
     my($self, $request) = @_;

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -1,7 +1,6 @@
 package LWP::Simple;
 
 use strict;
-use vars qw($ua %loop_check $FULL_LWP);
 
 our $VERSION = '6.19';
 
@@ -24,9 +23,9 @@ sub import
 }
 
 use LWP::UserAgent ();
-use HTTP::Status ();
 use HTTP::Date ();
-$ua = LWP::UserAgent->new;  # we create a global UserAgent object
+
+our $ua = LWP::UserAgent->new;  # we create a global UserAgent object
 $ua->agent("LWP::Simple/$VERSION ");
 $ua->env_proxy;
 


### PR DESCRIPTION
The ```use vars``` pragma is in place in many areas.  Where it makes sense, these have been converted to either ```use base 'Foo';``` or by declaring variables with ```our @EXPORT_OK = qw();``` or similar.

This PR should allow us to close #113 