### PR TITLE
skip tests pre HTTP::Message 6.07

### DIFF
--- a/t/base/default_content_type.t
+++ b/t/base/default_content_type.t
@@ -3,7 +3,8 @@ use warnings;
 use Test::More;
 
 use LWP::UserAgent;
-plan tests => 10;
+use HTTP::Request ();
+plan tests => 4;
 
 # Prevent environment from interfering with test:
 delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
@@ -13,40 +14,63 @@ delete $ENV{PERL_LWP_SSL_CA_FILE};
 delete $ENV{PERL_LWP_SSL_CA_PATH};
 delete $ENV{PERL_LWP_ENV_PROXY};
 
-my $ua = LWP::UserAgent->new;
+# we can only use HTTP::Request >= 6.07
+my $ver = $HTTP::Request::VERSION || '6.00';
+my $ver_ok = eval {HTTP::Request->VERSION("6.07");};
+diag "Some tests for the PUT method can only be run on ";
+diag "HTTP::Request version 6.07 or higher.";
+diag "If your version isn't good enough, we'll skip those.";
+diag "Your version is $ver and that's ". ($ver_ok ? '' : 'not '). 'good enough';
 
 # default_header 'Content-Type' should be honored in POST/PUT
 # if the "Content => 'string'" form is used. Otherwise, x-www-form-urlencoded
 # will be used
-
+my $url = "http://www.example.com";
+my $ua = LWP::UserAgent->new;
 $ua->default_header('Content-Type' => 'application/json');
-
 $ua->proxy(http => "loopback:");
 $ua->agent("foo/0.1");
 
-my $url = "http://www.example.com";
-
 # These forms will all be x-www-form-urlencoded
-for my $call (qw(post put)) {
+subtest 'PUT x-www-form-urlencoded' => sub {
+    plan skip_all => "HTTP::Request version not high enough" unless $ver_ok;
+    plan tests => 4;
     for my $arg (
         [ { cat => 'dog' }             ],
         [ [ cat => 'dog' ]             ],
         [ Content => { cat => 'dog' }, ],
         [ Content => [ cat => 'dog' ], ],
     ) {
-        my $ucall = uc $call;
-
-        is ($ua->$call($url, @$arg)->content, <<"EOT", "$call @$arg");
-$ucall http://www.example.com
+        is ($ua->put($url, @$arg)->content, <<"EOT", "put @$arg");
+PUT http://www.example.com
 User-Agent: foo/0.1
 Content-Length: 7
 Content-Type: application/x-www-form-urlencoded
 
 cat=dog
 EOT
-
     }
-}
+};
+
+# These forms will all be x-www-form-urlencoded
+subtest 'POST x-www-form-urlencoded' => sub {
+    plan tests => 4;
+    for my $arg (
+        [ { cat => 'dog' }             ],
+        [ [ cat => 'dog' ]             ],
+        [ Content => { cat => 'dog' }, ],
+        [ Content => [ cat => 'dog' ], ],
+    ) {
+        is ($ua->post($url, @$arg)->content, <<"EOT", "post @$arg");
+POST http://www.example.com
+User-Agent: foo/0.1
+Content-Length: 7
+Content-Type: application/x-www-form-urlencoded
+
+cat=dog
+EOT
+    }
+};
 
 # These should all use the default
 for my $call (qw(post put)) {
@@ -64,4 +88,3 @@ Content-Type: application/json
 EOT
 
 }
-


### PR DESCRIPTION
If [HTTP::Message](https://metacpan.org/pod/HTTP::Message) prior to version ```6.07``` is installed, we can't send hash or array references through to the ```content``` portion of the request.

Since this test set is specifically testing the differences in the default headers when passing different types of content, we need to skip a few tests when we detect that [HTTP::Message](https://metacpan.org/pod/HTTP::Message) versions 6.00, 6.01, 6.02, 6.03, 6.04, 6.05, or 6.06 are installed.

We can remove these skips later if we decide to up the prerequisite version of [HTTP::Message](https://metacpan.org/pod/HTTP::Message).