### PR TITLE
Update documentation to be a little cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ LWP::UserAgent - Web user agent class
 
 # SYNOPSIS
 
-    require LWP::UserAgent;
+    use strict;
+    use warnings;
+    use LWP::UserAgent ();
 
     my $ua = LWP::UserAgent->new;
     $ua->timeout(10);
@@ -30,55 +32,62 @@ then creates an instance of [HTTP::Request](https://metacpan.org/pod/HTTP::Reque
 needs to be performed. This request is then passed to one of the
 request method the UserAgent, which dispatches it using the relevant
 protocol, and returns a [HTTP::Response](https://metacpan.org/pod/HTTP::Response) object.  There are
-convenience methods for sending the most common request types: get(),
-head(), post(), put() and delete().  When using these methods then the
-creation of the request object is hidden as shown in the synopsis above.
+convenience methods for sending the most common request types:
+["get" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#get), ["head" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#head), ["post" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#post),
+["put" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#put) and ["delete" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#delete).  When using these
+methods, the creation of the request object is hidden as shown in the
+synopsis above.
 
-The basic approach of the library is to use HTTP style communication
+The basic approach of the library is to use HTTP-style communication
 for all protocol schemes.  This means that you will construct
 [HTTP::Request](https://metacpan.org/pod/HTTP::Request) objects and receive [HTTP::Response](https://metacpan.org/pod/HTTP::Response) objects even
 for non-HTTP resources like _gopher_ and _ftp_.  In order to achieve
-even more similarity to HTTP style communications, gopher menus and
+even more similarity to HTTP-style communications, _gopher_ menus and
 file directories are converted to HTML documents.
 
 # CONSTRUCTOR METHODS
 
 The following constructor methods are available:
 
-- $ua = LWP::UserAgent->new( %options )
+## new
 
-    This method constructs a new [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) object and returns it.
-    Key/value pair arguments may be provided to set up the initial state.
-    The following options correspond to attribute methods described below:
+    my $ua = LWP::UserAgent->new( %options )
 
-        KEY                     DEFAULT
-        -----------             --------------------
-        agent                   "libwww-perl/#.###"
-        from                    undef
-        conn_cache              undef
-        cookie_jar              undef
-        default_headers         HTTP::Headers->new
-        local_address           undef
-        ssl_opts                { verify_hostname => 1 }
-        max_size                undef
-        max_redirect            7
-        parse_head              1
-        protocols_allowed       undef
-        protocols_forbidden     undef
-        requests_redirectable   ['GET', 'HEAD']
-        timeout                 180
+This method constructs a new [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) object and returns it.
+Key/value pair arguments may be provided to set up the initial state.
+The following options correspond to attribute methods described below:
 
-    The following additional options are also accepted: If the `env_proxy` option
-    is passed in with a TRUE value, then proxy settings are read from environment
-    variables (see env\_proxy() method below).  If `env_proxy` isn't provided the
-    `PERL_LWP_ENV_PROXY` environment variable controls if env\_proxy() is called
-    during initialization.  If the `keep_alive` option is passed in, then a
-    `LWP::ConnCache` is set up (see conn\_cache() method below).  The `keep_alive`
-    value is passed on as the `total_capacity` for the connection cache.
+    KEY                     DEFAULT
+    -----------             --------------------
+    agent                   "libwww-perl/#.###"
+    from                    undef
+    conn_cache              undef
+    cookie_jar              undef
+    default_headers         HTTP::Headers->new
+    local_address           undef
+    ssl_opts                { verify_hostname => 1 }
+    max_size                undef
+    max_redirect            7
+    parse_head              1
+    protocols_allowed       undef
+    protocols_forbidden     undef
+    requests_redirectable   ['GET', 'HEAD']
+    timeout                 180
 
-- $ua->clone
+The following additional options are also accepted: If the `env_proxy` option
+is passed in with a true value, then proxy settings are read from environment
+variables (see ["env\_proxy" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#env_proxy)). If `env_proxy` isn't provided, the
+`PERL_LWP_ENV_PROXY` environment variable controls if
+["env\_proxy" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#env_proxy) is called during initialization.  If the
+`keep_alive` option is passed in, then a `LWP::ConnCache` is set up (see
+["conn\_cache" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#conn_cache)).  The `keep_alive` value is passed on as the
+`total_capacity` for the connection cache.
 
-    Returns a copy of the LWP::UserAgent object.
+## clone
+
+    my $ua2 = $ua->clone;
+
+Returns a copy of the [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) object.
 
 # ATTRIBUTES
 
@@ -90,398 +99,448 @@ The following attribute methods are provided.  The attribute value is
 left unchanged if no argument is given.  The return value from each
 method is the old attribute value.
 
-- $ua->agent
-- $ua->agent( $product\_id )
+## \_agent
 
-    Get/set the product token that is used to identify the user agent on
-    the network.  The agent value is sent as the "User-Agent" header in
-    the requests.  The default is the string returned by the \_agent()
-    method (see below).
+    my $agent_string = $ua->_agent;
 
-    If the $product\_id ends with space then the \_agent() string is
-    appended to it.
+Returns the default agent identifier.  This is a string of the form
+`libwww-perl/#.###`, where `#.###` is substituted with the version number
+of this library.
 
-    The user agent string should be one or more simple product identifiers
-    with an optional version number separated by the "/" character.
-    Examples are:
+## agent
 
-        $ua->agent('Checkbot/0.4 ' . $ua->_agent);
-        $ua->agent('Checkbot/0.4 ');    # same as above
-        $ua->agent('Mozilla/5.0');
-        $ua->agent("");                 # don't identify
+    my $agent = $ua->agent;
+    $ua->agent( $product_id );
+    $ua->agent('Checkbot/0.4 ' . $ua->_agent);
+    $ua->agent('Checkbot/0.4 ');    # same as above
+    $ua->agent('Mozilla/5.0');
+    $ua->agent("");                 # don't identify
 
-- $ua->\_agent
+Get/set the product token that is used to identify the user agent on
+the network.  The agent value is sent as the `User-Agent` header in
+the requests.  The default is the string returned by the
+["\_agent" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#agent) method.
 
-    Returns the default agent identifier.  This is a string of the form
-    "libwww-perl/#.###", where "#.###" is substituted with the version number
-    of this library.
+If the `$product_id` ends with space then the ["\_agent" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#agent) string
+is appended to it.
 
-- $ua->from
-- $ua->from( $email\_address )
+The user agent string should be one or more simple product identifiers
+with an optional version number separated by the `/` character.
 
-    Get/set the e-mail address for the human user who controls
-    the requesting user agent.  The address should be machine-usable, as
-    defined in RFC 822.  The `from` value is send as the "From" header in
-    the requests.  Example:
+## from
 
-        $ua->from('gaas@cpan.org');
+    my $from = $ua->from;
+    $ua->from('foo@bar.com');
 
-    The default is to not send a "From" header.  See the default\_headers()
-    method for the more general interface that allow any header to be defaulted.
+Get/set the email address for the human user who controls
+the requesting user agent.  The address should be machine-usable, as
+defined in [RFC2822](https://tools.ietf.org/html/rfc2822). The `from` value
+is sent as the `From` header in the requests.
 
-- $ua->cookie\_jar
-- $ua->cookie\_jar( $cookie\_jar\_obj )
+The default is to not send a `From` header.  See
+["default\_headers" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#default_headers) for the more general interface that allow
+any header to be defaulted.
 
-    Get/set the cookie jar object to use.  The only requirement is that
-    the cookie jar object must implement the extract\_cookies($response) and
-    add\_cookie\_header($request) methods.  These methods will then be
-    invoked by the user agent as requests are sent and responses are
-    received.  Normally this will be a [HTTP::Cookies](https://metacpan.org/pod/HTTP::Cookies) object or some
-    subclass.
+## cookie\_jar
 
-    The default is to have no cookie\_jar, i.e. never automatically add
-    "Cookie" headers to the requests.
+    my $jar = $ua->cookie_jar;
+    $ua->cookie_jar( $cookie_jar_obj );
 
-    Shortcut: If a reference to a plain hash is passed in as the
-    $cookie\_jar\_object, then it is replaced with an instance of
-    [HTTP::Cookies](https://metacpan.org/pod/HTTP::Cookies) that is initialized based on the hash.  This form also
-    automatically loads the [HTTP::Cookies](https://metacpan.org/pod/HTTP::Cookies) module.  It means that:
+Get/set the cookie jar object to use.  The only requirement is that
+the cookie jar object must implement the `extract_cookies($response)` and
+`add_cookie_header($request)` methods.  These methods will then be
+invoked by the user agent as requests are sent and responses are
+received.  Normally this will be a [HTTP::Cookies](https://metacpan.org/pod/HTTP::Cookies) object or some
+subclass.
 
-        $ua->cookie_jar({ file => "$ENV{HOME}/.cookies.txt" });
+The default is to have no cookie jar, i.e. never automatically add
+`Cookie` headers to the requests.
 
-    is really just a shortcut for:
+Shortcut: If a reference to a plain hash is passed in, it is replaced with an
+instance of [HTTP::Cookies](https://metacpan.org/pod/HTTP::Cookies) that is initialized based on the hash. This form
+also automatically loads the [HTTP::Cookies](https://metacpan.org/pod/HTTP::Cookies) module.  It means that:
 
-        require HTTP::Cookies;
-        $ua->cookie_jar(HTTP::Cookies->new(file => "$ENV{HOME}/.cookies.txt"));
+    $ua->cookie_jar({ file => "$ENV{HOME}/.cookies.txt" });
 
-- $ua->default\_headers
-- $ua->default\_headers( $headers\_obj )
+is really just a shortcut for:
 
-    Get/set the headers object that will provide default header values for
-    any requests sent.  By default this will be an empty [HTTP::Headers](https://metacpan.org/pod/HTTP::Headers)
-    object.
+    require HTTP::Cookies;
+    $ua->cookie_jar(HTTP::Cookies->new(file => "$ENV{HOME}/.cookies.txt"));
 
-- $ua->default\_header( $field )
-- $ua->default\_header( $field => $value )
+## default\_headers
 
-    This is just a short-cut for $ua->default\_headers->header( $field =>
-    $value ). Example:
+    my $headers = $ua->default_headers;
+    $ua->default_headers( $headers_obj );
 
-        $ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
-        $ua->default_header('Accept-Language' => "no, en");
+Get/set the headers object that will provide default header values for
+any requests sent.  By default this will be an empty [HTTP::Headers](https://metacpan.org/pod/HTTP::Headers)
+object.
 
-- $ua->conn\_cache
-- $ua->conn\_cache( $cache\_obj )
+## default\_header
 
-    Get/set the [LWP::ConnCache](https://metacpan.org/pod/LWP::ConnCache) object to use.  See [LWP::ConnCache](https://metacpan.org/pod/LWP::ConnCache)
-    for details.
+    $ua->default_header( $field );
+    $ua->default_header( $field => $value );
+    $ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
+    $ua->default_header('Accept-Language' => "no, en");
 
-- $ua->credentials( $netloc, $realm )
-- $ua->credentials( $netloc, $realm, $uname, $pass )
+This is just a shortcut for
+`$ua->default_headers->header( $field => $value )`.
 
-    Get/set the user name and password to be used for a realm.
+## conn\_cache
 
-    The $netloc is a string of the form "&lt;host>:&lt;port>".  The username and
-    password will only be passed to this server.  Example:
+    my $cache_obj = $ua->conn_cache;
+    $ua->conn_cache( $cache_obj );
 
-        $ua->credentials("www.example.com:80", "Some Realm", "foo", "secret");
+Get/set the [LWP::ConnCache](https://metacpan.org/pod/LWP::ConnCache) object to use.  See [LWP::ConnCache](https://metacpan.org/pod/LWP::ConnCache)
+for details.
 
-- $ua->local\_address
-- $ua->local\_address( $address )
+## credentials
 
-    Get/set the local interface to bind to for network connections.  The interface
-    can be specified as a hostname or an IP address.  This value is passed as the
-    `LocalAddr` argument to [IO::Socket::INET](https://metacpan.org/pod/IO::Socket::INET).
+    my $creds = $ua->credentials();
+    $ua->credentials( $netloc, $realm );
+    $ua->credentials( $netloc, $realm, $uname, $pass );
+    $ua->credentials("www.example.com:80", "Some Realm", "foo", "secret");
 
-- $ua->max\_size
-- $ua->max\_size( $bytes )
+Get/set the user name and password to be used for a realm.
 
-    Get/set the size limit for response content.  The default is `undef`,
-    which means that there is no limit.  If the returned response content
-    is only partial, because the size limit was exceeded, then a
-    "Client-Aborted" header will be added to the response.  The content
-    might end up longer than `max_size` as we abort once appending a
-    chunk of data makes the length exceed the limit.  The "Content-Length"
-    header, if present, will indicate the length of the full content and
-    will normally not be the same as `length($res->content)`.
+The `$netloc` is a string of the form `<host>:<port>`.  The username and
+password will only be passed to this server.
 
-- $ua->max\_redirect
-- $ua->max\_redirect( $n )
+## local\_address
 
-    This reads or sets the object's limit of how many times it will obey
-    redirection responses in a given request cycle.
+    my $address = $ua->local_address;
+    $ua->local_address( $address );
 
-    By default, the value is 7. This means that if you call request()
-    method and the response is a redirect elsewhere which is in turn a
-    redirect, and so on seven times, then LWP gives up after that seventh
-    request.
+Get/set the local interface to bind to for network connections.  The interface
+can be specified as a hostname or an IP address.  This value is passed as the
+`LocalAddr` argument to [IO::Socket::INET](https://metacpan.org/pod/IO::Socket::INET).
 
-- $ua->parse\_head
-- $ua->parse\_head( $boolean )
+## max\_size
 
-    Get/set a value indicating whether we should initialize response
-    headers from the &lt;head> section of HTML documents. The default is
-    TRUE.  Do not turn this off, unless you know what you are doing.
+    my $size = $ua->max_size;
+    $ua->max_size( $bytes );
 
-- $ua->protocols\_allowed
-- $ua->protocols\_allowed( \\@protocols )
+Get/set the size limit for response content.  The default is `undef`,
+which means that there is no limit.  If the returned response content
+is only partial, because the size limit was exceeded, then a
+`Client-Aborted` header will be added to the response.  The content
+might end up longer than `max_size` as we abort once appending a
+chunk of data makes the length exceed the limit.  The `Content-Length`
+header, if present, will indicate the length of the full content and
+will normally not be the same as `length($res->content)`.
 
-    This reads (or sets) this user agent's list of protocols that the
-    request methods will exclusively allow.  The protocol names are case
-    insensitive.
+## max\_redirect
 
-    For example: `$ua->protocols_allowed( [ 'http', 'https'] );`
-    means that this user agent will _allow only_ those protocols,
-    and attempts to use this user agent to access URLs with any other
-    schemes (like "ftp://...") will result in a 500 error.
+    my $max = $ua->max_redirect;
+    $ua->max_redirect( $n );
 
-    To delete the list, call: `$ua->protocols_allowed(undef)`
+This reads or sets the object's limit of how many times it will obey
+redirection responses in a given request cycle.
 
-    By default, an object has neither a `protocols_allowed` list, nor a
-    `protocols_forbidden` list.
+By default, the value is `7`. This means that if you call ["request" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#request)
+and the response is a redirect elsewhere which is in turn a
+redirect, and so on seven times, then LWP gives up after that seventh
+request.
 
-    Note that having a `protocols_allowed` list causes any
-    `protocols_forbidden` list to be ignored.
+## parse\_head
 
-- $ua->protocols\_forbidden
-- $ua->protocols\_forbidden( \\@protocols )
+    my $bool = $ua->parse_head;
+    $ua->parse_head( $boolean );
 
-    This reads (or sets) this user agent's list of protocols that the
-    request method will _not_ allow. The protocol names are case
-    insensitive.
+Get/set a value indicating whether we should initialize response
+headers from the &lt;head> section of HTML documents. The default is
+true. _Do not turn this off_ unless you know what you are doing.
 
-    For example: `$ua->protocols_forbidden( [ 'file', 'mailto'] );`
-    means that this user agent will _not_ allow those protocols, and
-    attempts to use this user agent to access URLs with those schemes
-    will result in a 500 error.
+## protocols\_allowed
 
-    To delete the list, call: `$ua->protocols_forbidden(undef)`
+    my $aref = $ua->protocols_allowed;      # get allowed protocols
+    $ua->protocols_allowed( \@protocols );  # allow ONLY these
+    $ua->protocols_allowed(undef);          # delete the list
+    $ua->protocols_allowed(['http',]);      # ONLY allow http
 
-- $ua->requests\_redirectable
-- $ua->requests\_redirectable( \\@requests )
+By default, an object has neither a `protocols_allowed` list, nor a
+["protocols\_forbidden" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#protocols_forbidden) list.
 
-    This reads or sets the object's list of request names that
-    `$ua->redirect_ok(...)` will allow redirection for.  By
-    default, this is `['GET', 'HEAD']`, as per RFC 2616.  To
-    change to include 'POST', consider:
+This reads (or sets) this user agent's list of protocols that the
+request methods will exclusively allow.  The protocol names are case
+insensitive.
 
-        push @{ $ua->requests_redirectable }, 'POST';
+For example: `$ua->protocols_allowed( [ 'http', 'https'] );`
+means that this user agent will _allow only_ those protocols,
+and attempts to use this user agent to access URLs with any other
+schemes (like `ftp://...`) will result in a 500 error.
 
-- $ua->show\_progress
-- $ua->show\_progress( $boolean )
+Note that having a `protocols_allowed` list causes any
+["protocols\_forbidden" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#protocols_forbidden) list to be ignored.
 
-    Get/set a value indicating whether a progress bar should be displayed
-    on the terminal as requests are processed. The default is FALSE.
+## protocols\_forbidden
 
-- $ua->timeout
-- $ua->timeout( $secs )
+    my $aref = $ua->protocols_forbidden;    # get the forbidden list
+    $ua->protocols_forbidden(\@protocols);  # do not allow these
+    $ua->protocols_forbidden(['http',]);    # All http reqs get a 500
+    $ua->protocols_forbidden(undef);        # delete the list
 
-    Get/set the timeout value in seconds. The default timeout() value is
-    180 seconds, i.e. 3 minutes.
+This reads (or sets) this user agent's list of protocols that the
+request method will _not_ allow. The protocol names are case
+insensitive.
 
-    The requests is aborted if no activity on the connection to the server
-    is observed for `timeout` seconds.  This means that the time it takes
-    for the complete transaction and the request() method to actually
-    return might be longer.
+For example: `$ua->protocols_forbidden( [ 'file', 'mailto'] );`
+means that this user agent will _not_ allow those protocols, and
+attempts to use this user agent to access URLs with those schemes
+will result in a 500 error.
 
-- $ua->ssl\_opts
-- $ua->ssl\_opts( $key )
-- $ua->ssl\_opts( $key => $value )
+## requests\_redirectable
 
-    Get/set the options for SSL connections.  Without argument return the list
-    of options keys currently set.  With a single argument return the current
-    value for the given option.  With 2 arguments set the option value and return
-    the old.  Setting an option to the value `undef` removes this option.
+    my $aref = $ua->requests_redirectable;
+    $ua->requests_redirectable( \@requests );
+    $ua->requests_redirectable(['GET', 'HEAD',]); # the default
 
-    The options that LWP relates to are:
+This reads or sets the object's list of request names that
+["redirect\_ok" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#redirect_ok) will allow redirection for. By default, this
+is `['GET', 'HEAD']`, as per [RFC 2616](https://tools.ietf.org/html/rfc2616).
+To change to include `POST`, consider:
 
-    - `verify_hostname` => $bool
+    push @{ $ua->requests_redirectable }, 'POST';
 
-        When TRUE LWP will for secure protocol schemes ensure it connects to servers
-        that have a valid certificate matching the expected hostname.  If FALSE no
-        checks are made and you can't be sure that you communicate with the expected peer.
-        The no checks behaviour was the default for libwww-perl-5.837 and earlier releases.
+## show\_progress
 
-        This option is initialized from the [PERL\_LWP\_SSL\_VERIFY\_HOSTNAME](https://metacpan.org/pod/PERL_LWP_SSL_VERIFY_HOSTNAME) environment
-        variable.  If this environment variable isn't set; then `verify_hostname`
-        defaults to 1.
+    my $bool = $ua->show_progress;
+    $ua->show_progress( $boolean );
 
-    - `SSL_ca_file` => $path
+Get/set a value indicating whether a progress bar should be displayed
+on the terminal as requests are processed. The default is false.
 
-        The path to a file containing Certificate Authority certificates.
-        A default setting for this option is provided by checking the environment
-        variables `PERL_LWP_SSL_CA_FILE` and `HTTPS_CA_FILE` in order.
+## timeout
 
-    - `SSL_ca_path` => $path
+    my $secs = $ua->timeout;
+    $ua->timeout( $secs );
 
-        The path to a directory containing files containing Certificate Authority
-        certificates.
-        A default setting for this option is provided by checking the environment
-        variables `PERL_LWP_SSL_CA_PATH` and `HTTPS_CA_DIR` in order.
+Get/set the timeout value in seconds. The default value is
+180 seconds, i.e. 3 minutes.
 
-    Other options can be set and are processed directly by the SSL Socket implementation
-    in use.  See [IO::Socket::SSL](https://metacpan.org/pod/IO::Socket::SSL) or [Net::SSL](https://metacpan.org/pod/Net::SSL) for details.
+The requests is aborted if no activity on the connection to the server
+is observed for `timeout` seconds.  This means that the time it takes
+for the complete transaction and the ["request" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#request) method to
+actually return might be longer.
 
-    The libwww-perl core no longer bundles protocol plugins for SSL.  You will need
-    to install [LWP::Protocol::https](https://metacpan.org/pod/LWP::Protocol::https) separately to enable support for processing
-    https-URLs.
+## ssl\_opts
 
-## Proxy attributes
+    my @keys = $ua->ssl_opts;
+    my $val = $ua->ssl_opts( $key );
+    $ua->ssl_opts( $key => $value );
+
+Get/set the options for SSL connections.  Without argument return the list
+of options keys currently set.  With a single argument return the current
+value for the given option.  With 2 arguments set the option value and return
+the old.  Setting an option to the value `undef` removes this option.
+
+The options that LWP relates to are:
+
+- `verify_hostname` => $bool
+
+    When TRUE LWP will for secure protocol schemes ensure it connects to servers
+    that have a valid certificate matching the expected hostname.  If FALSE no
+    checks are made and you can't be sure that you communicate with the expected peer.
+    The no checks behaviour was the default for libwww-perl-5.837 and earlier releases.
+
+    This option is initialized from the [PERL\_LWP\_SSL\_VERIFY\_HOSTNAME](https://metacpan.org/pod/PERL_LWP_SSL_VERIFY_HOSTNAME) environment
+    variable.  If this environment variable isn't set; then `verify_hostname`
+    defaults to 1.
+
+- `SSL_ca_file` => $path
+
+    The path to a file containing Certificate Authority certificates.
+    A default setting for this option is provided by checking the environment
+    variables `PERL_LWP_SSL_CA_FILE` and `HTTPS_CA_FILE` in order.
+
+- `SSL_ca_path` => $path
+
+    The path to a directory containing files containing Certificate Authority
+    certificates.
+    A default setting for this option is provided by checking the environment
+    variables `PERL_LWP_SSL_CA_PATH` and `HTTPS_CA_DIR` in order.
+
+Other options can be set and are processed directly by the SSL Socket implementation
+in use.  See [IO::Socket::SSL](https://metacpan.org/pod/IO::Socket::SSL) or [Net::SSL](https://metacpan.org/pod/Net::SSL) for details.
+
+The libwww-perl core no longer bundles protocol plugins for SSL.  You will need
+to install [LWP::Protocol::https](https://metacpan.org/pod/LWP::Protocol::https) separately to enable support for processing
+https-URLs.
+
+# Proxy attributes
 
 The following methods set up when requests should be passed via a
 proxy server.
 
-- $ua->proxy(\\@schemes, $proxy\_url)
-- $ua->proxy($scheme, $proxy\_url)
+## proxy
 
-    Set/retrieve proxy URL for a scheme:
+    $ua->proxy(\@schemes, $proxy_url)
+    $ua->proxy(['http', 'ftp'], 'http://proxy.sn.no:8001/');
+    # or, for a single scheme
+    $ua->proxy($scheme, $proxy_url)
+    $ua->proxy('gopher', 'http://proxy.sn.no:8001/');
 
-        $ua->proxy(['http', 'ftp'], 'http://proxy.sn.no:8001/');
-        $ua->proxy('gopher', 'http://proxy.sn.no:8001/');
+Set/retrieve proxy URL for a scheme.
 
-    The first form specifies that the URL is to be used as a proxy for
-    access methods listed in the list in the first method argument,
-    i.e. 'http' and 'ftp'.
+The first form specifies that the URL is to be used as a proxy for
+access methods listed in the list in the first method argument,
+i.e. `http` and `ftp`.
 
-    The second form shows a shorthand form for specifying
-    proxy URL for a single access scheme.
+The second form shows a shorthand form for specifying
+proxy URL for a single access scheme.
 
-- $ua->no\_proxy( $domain, ... )
+## no\_proxy
 
-    Do not proxy requests to the given domains.  Calling no\_proxy without
-    any domains clears the list of domains. For example:
+    $ua->no_proxy( @domains );
+    $ua->no_proxy('localhost', 'example.com');
+    $ua->no_proxy(); # clear the list
 
-        $ua->no_proxy('localhost', 'example.com');
+Do not proxy requests to the given domains.  Calling `no_proxy` without
+any domains clears the list of domains.
 
-- $ua->env\_proxy
+## env\_proxy
 
-    Load proxy settings from \*\_proxy environment variables.  You might
-    specify proxies like this (sh-syntax):
+    $ua->env_proxy;
 
-        gopher_proxy=http://proxy.my.place/
-        wais_proxy=http://proxy.my.place/
-        no_proxy="localhost,example.com"
-        export gopher_proxy wais_proxy no_proxy
+Load proxy settings from `*_proxy` environment variables.  You might
+specify proxies like this (sh-syntax):
 
-    csh or tcsh users should use the `setenv` command to define these
-    environment variables.
+    gopher_proxy=http://proxy.my.place/
+    wais_proxy=http://proxy.my.place/
+    no_proxy="localhost,example.com"
+    export gopher_proxy wais_proxy no_proxy
 
-    On systems with case insensitive environment variables there exists a
-    name clash between the CGI environment variables and the `HTTP_PROXY`
-    environment variable normally picked up by env\_proxy().  Because of
-    this `HTTP_PROXY` is not honored for CGI scripts.  The
-    `CGI_HTTP_PROXY` environment variable can be used instead.
+csh or tcsh users should use the `setenv` command to define these
+environment variables.
 
-## Handlers
+On systems with case insensitive environment variables there exists a
+name clash between the CGI environment variables and the `HTTP_PROXY`
+environment variable normally picked up by `env_proxy`.  Because of
+this `HTTP_PROXY` is not honored for CGI scripts.  The
+`CGI_HTTP_PROXY` environment variable can be used instead.
+
+# Handlers
 
 Handlers are code that injected at various phases during the
 processing of requests.  The following methods are provided to manage
 the active handlers:
 
-- $ua->add\_handler( $phase => \\&cb, %matchspec )
+## add\_handler
 
-    Add handler to be invoked in the given processing phase.  For how to
-    specify %matchspec see ["Matching" in HTTP::Config](https://metacpan.org/pod/HTTP::Config#Matching).
+    $ua->add_handler( $phase => \&cb, %matchspec )
 
-    The possible values $phase and the corresponding callback signatures are:
+Add handler to be invoked in the given processing phase.  For how to
+specify `%matchspec` see ["Matching" in HTTP::Config](https://metacpan.org/pod/HTTP::Config#Matching).
 
-    - request\_preprepare => sub { my($request, $ua, $h) = @\_; ... }
+The possible values `$phase` and the corresponding callback signatures are:
 
-        The handler is called before the `request_prepare` and other standard
-        initialization of the request.  This can be used to set up headers
-        and attributes that the `request_prepare` handler depends on.  Proxy
-        initialization should take place here; but in general don't register
-        handlers for this phase.
+- request\_preprepare => sub { my($request, $ua, $h) = @\_; ... }
 
-    - request\_prepare => sub { my($request, $ua, $h) = @\_; ... }
+    The handler is called before the `request_prepare` and other standard
+    initialization of the request.  This can be used to set up headers
+    and attributes that the `request_prepare` handler depends on.  Proxy
+    initialization should take place here; but in general don't register
+    handlers for this phase.
 
-        The handler is called before the request is sent and can modify the
-        request any way it see fit.  This can for instance be used to add
-        certain headers to specific requests.
+- request\_prepare => sub { my($request, $ua, $h) = @\_; ... }
 
-        The method can assign a new request object to $\_\[0\] to replace the
-        request that is sent fully.
+    The handler is called before the request is sent and can modify the
+    request any way it see fit.  This can for instance be used to add
+    certain headers to specific requests.
 
-        The return value from the callback is ignored.  If an exception is
-        raised it will abort the request and make the request method return a
-        "400 Bad request" response.
+    The method can assign a new request object to $\_\[0\] to replace the
+    request that is sent fully.
 
-    - request\_send => sub { my($request, $ua, $h) = @\_; ... }
+    The return value from the callback is ignored.  If an exception is
+    raised it will abort the request and make the request method return a
+    "400 Bad request" response.
 
-        This handler gets a chance of handling requests before they're sent to the
-        protocol handlers.  It should return an HTTP::Response object if it
-        wishes to terminate the processing; otherwise it should return nothing.
+- request\_send => sub { my($request, $ua, $h) = @\_; ... }
 
-        The `response_header` and `response_data` handlers will not be
-        invoked for this response, but the `response_done` will be.
+    This handler gets a chance of handling requests before they're sent to the
+    protocol handlers.  It should return an HTTP::Response object if it
+    wishes to terminate the processing; otherwise it should return nothing.
 
-    - response\_header => sub { my($response, $ua, $h) = @\_; ... }
+    The `response_header` and `response_data` handlers will not be
+    invoked for this response, but the `response_done` will be.
 
-        This handler is called right after the response headers have been
-        received, but before any content data.  The handler might set up
-        handlers for data and might croak to abort the request.
+- response\_header => sub { my($response, $ua, $h) = @\_; ... }
 
-        The handler might set the $response->{default\_add\_content} value to
-        control if any received data should be added to the response object
-        directly.  This will initially be false if the $ua->request() method
-        was called with a $content\_file or $content\_cb argument; otherwise true.
+    This handler is called right after the response headers have been
+    received, but before any content data.  The handler might set up
+    handlers for data and might croak to abort the request.
 
-    - response\_data => sub { my($response, $ua, $h, $data) = @\_; ... }
+    The handler might set the $response->{default\_add\_content} value to
+    control if any received data should be added to the response object
+    directly.  This will initially be false if the $ua->request() method
+    was called with a $content\_file or $content\_cb argument; otherwise true.
 
-        This handler is called for each chunk of data received for the
-        response.  The handler might croak to abort the request.
+- response\_data => sub { my($response, $ua, $h, $data) = @\_; ... }
 
-        This handler needs to return a TRUE value to be called again for
-        subsequent chunks for the same request.
+    This handler is called for each chunk of data received for the
+    response.  The handler might croak to abort the request.
 
-    - response\_done => sub { my($response, $ua, $h) = @\_; ... }
+    This handler needs to return a TRUE value to be called again for
+    subsequent chunks for the same request.
 
-        The handler is called after the response has been fully received, but
-        before any redirect handling is attempted.  The handler can be used to
-        extract information or modify the response.
+- response\_done => sub { my($response, $ua, $h) = @\_; ... }
 
-    - response\_redirect => sub { my($response, $ua, $h) = @\_; ... }
+    The handler is called after the response has been fully received, but
+    before any redirect handling is attempted.  The handler can be used to
+    extract information or modify the response.
 
-        The handler is called in $ua->request after `response_done`.  If the
-        handler returns an HTTP::Request object we'll start over with processing
-        this request instead.
+- response\_redirect => sub { my($response, $ua, $h) = @\_; ... }
 
-- $ua->remove\_handler( undef, %matchspec )
-- $ua->remove\_handler( $phase, %matchspec )
+    The handler is called in $ua->request after `response_done`.  If the
+    handler returns an HTTP::Request object we'll start over with processing
+    this request instead.
 
-    Remove handlers that match the given %matchspec.  If $phase is not
-    provided remove handlers from all phases.
+## remove\_handler
 
-    Be careful as calling this function with %matchspec that is not
-    specific enough can remove handlers not owned by you.  It's probably
-    better to use the set\_my\_handler() method instead.
+    $ua->remove_handler( undef, %matchspec );
+    $ua->remove_handler( $phase, %matchspec );
+    $ua->remove_handlers(); # REMOVE ALL HANDLERS IN ALL PHASES
 
-    The removed handlers are returned.
+Remove handlers that match the given `%matchspec`.  If `$phase` is not
+provided, remove handlers from all phases.
 
-- $ua->set\_my\_handler( $phase, $cb, %matchspec )
+Be careful as calling this function with `%matchspec` that is not
+specific enough can remove handlers not owned by you.  It's probably
+better to use the ["set\_my\_handler" in LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent#set_my_handler) method instead.
 
-    Set handlers private to the executing subroutine.  Works by defaulting
-    an `owner` field to the %matchspec that holds the name of the called
-    subroutine.  You might pass an explicit `owner` to override this.
+The removed handlers are returned.
 
-    If $cb is passed as `undef`, remove the handler.
+## set\_my\_handler
 
-- $ua->get\_my\_handler( $phase, %matchspec )
-- $ua->get\_my\_handler( $phase, %matchspec, $init )
+    $ua->set_my_handler( $phase, $cb, %matchspec );
+    $ua->set_my_handler($phase, undef); # remove handler for phase
 
-    Will retrieve the matching handler as hash ref.
+Set handlers private to the executing subroutine.  Works by defaulting
+an `owner` field to the `%matchspec` that holds the name of the called
+subroutine.  You might pass an explicit `owner` to override this.
 
-    If `$init` is passed as a TRUE value, create and add the
-    handler if it's not found.  If $init is a subroutine reference, then
-    it's called with the created handler hash as argument.  This sub might
-    populate the hash with extra fields; especially the callback.  If
-    $init is a hash reference, merge the hashes.
+If $cb is passed as `undef`, remove the handler.
 
-- $ua->handlers( $phase, $request )
-- $ua->handlers( $phase, $response )
+## get\_my\_handler
 
-    Returns the handlers that apply to the given request or response at
-    the given processing phase.
+    $ua->get_my_handler( $phase, %matchspec );
+    $ua->get_my_handler( $phase, %matchspec, $init );
+
+Will retrieve the matching handler as hash ref.
+
+If `$init` is passed as a true value, create and add the
+handler if it's not found.  If `$init` is a subroutine reference, then
+it's called with the created handler hash as argument.  This sub might
+populate the hash with extra fields; especially the callback.  If
+`$init` is a hash reference, merge the hashes.
+
+## handlers
+
+    $ua->handlers( $phase, $request )
+    $ua->handlers( $phase, $response )
+
+Returns the handlers that apply to the given request or response at
+the given processing phase.
 
 # REQUEST METHODS
 

--- a/dist.ini
+++ b/dist.ini
@@ -93,7 +93,7 @@ bail_out_on_fail = 1
 xt_mode = 1
 
 [Test::Portability]
-; TODO perltidy for NoTabs and namespace::autoclean 
+; TODO perltidy for NoTabs and namespace::autoclean
 ; [Test::CleanNamespaces] ; TODO
 ; [Test::NoTabs] ; TODO
 [Test::EOL]
@@ -232,6 +232,8 @@ stopword = Mailto
 stopword = peterm
 stopword = de
 stopword = erik
+stopword = getprint
+stopword = getstore
 
 [RunExtraTests]
 

--- a/lib/LWP/ConnCache.pm
+++ b/lib/LWP/ConnCache.pm
@@ -191,30 +191,56 @@ change in the future.
 The C<LWP::ConnCache> class is the standard connection cache manager
 for L<LWP::UserAgent>.
 
+=head1 METHODS
+
 The following basic methods are provided:
 
-=over
+=head2 new
 
-=item $cache = LWP::ConnCache->new( %options )
+    my $cache = LWP::ConnCache->new( %options )
 
 This method constructs a new L<LWP::ConnCache> object.  The only
-option currently accepted is 'total_capacity'.  If specified it
-initialize the total_capacity option.  It defaults to the value 1.
+option currently accepted is C<total_capacity>.  If specified it
+initialize the L<LWP::ConnCache/total_capacity> option. It defaults to C<1>.
 
-=item $cache->total_capacity( [$num_connections] )
+=head2 total_capacity
+
+    my $cap = $cache->total_capacity;
+    $cache->total_capacity(0); # drop all immediately
+    $cache->total_capacity(undef); # no limit
+    $cache->total_capacity($number);
 
 Get/sets the number of connection that will be cached.  Connections
 will start to be dropped when this limit is reached.  If set to C<0>,
 then all connections are immediately dropped.  If set to C<undef>,
 then there is no limit.
 
-=item $cache->capacity($type, [$num_connections] )
+=head2 capacity
+
+    my $http_capacity = $cache->capacity('http');
+    $cache->capacity('http', 2 );
 
 Get/set a limit for the number of connections of the specified type
-that can be cached.  The $type will typically be a short string like
+that can be cached.  The first parameter is a short string like
 "http" or "ftp".
 
-=item $cache->drop( [$checker, [$reason]] )
+=head2 drop
+
+    $cache->drop(); # Drop ALL connections
+    # which is just a synonym for:
+    $cache->drop(sub{1}); # Drop ALL connections
+    # drop all connections older than 22 seconds and add a reason for it!
+    $cache->drop(22, "Older than 22 secs dropped");
+    # which is just a synonym for:
+    $cache->drop(sub {
+        my ($conn, $type, $key, $deposit_time) = @_;
+        if ($deposit_time < 22) {
+            # true values drop the connection
+            return 1;
+        }
+        # false values don't drop the connection
+        return 0;
+    }, "Older than 22 secs dropped" );
 
 Drop connections by some criteria.  The $checker argument is a
 subroutine that is called for each connection.  If the routine returns
@@ -227,41 +253,49 @@ connections untouched that the given number of seconds or more are
 dropped.  If $checker is a string then all connections of the given
 type are dropped.
 
-The $reason argument is passed on to the dropped() method.
+The C<reason> is passed on to the L<LWP::ConnCache/dropped> method.
 
-=item $cache->prune
+=head2 prune
+
+    $cache->prune();
 
 Calling this method will drop all connections that are dead.  This is
-tested by calling the ping() method on the connections.  If the ping()
-method exists and returns a FALSE value, then the connection is
-dropped.
+tested by calling the L<LWP::ConnCache/ping> method on the connections. If
+the L<LWP::ConnCache/ping> method exists and returns a false value, then the
+connection is dropped.
 
-=item $cache->get_types
+=head2 get_types
 
-This returns all the 'type' fields used for the currently cached
+    my @types = $cache->get_types();
+
+This returns all the C<type> fields used for the currently cached
 connections.
 
-=item $cache->get_connections( [$type] )
+=head2 get_connections
+
+    my @conns = $cache->get_connections(); # all connections
+    my @conns = $cache->get_connections('http'); # connections for http
 
 This returns all connection objects of the specified type.  If no type
 is specified then all connections are returned.  In scalar context the
 number of cached connections of the specified type is returned.
 
-=back
-
+=head1 PROTOCOL METHODS
 
 The following methods are called by low-level protocol modules to
 try to save away connections and to get them back.
 
-=over
+=head2 deposit
 
-=item $cache->deposit($type, $key, $conn)
+    $cache->deposit($type, $key, $conn);
 
-This method adds a new connection to the cache.  As a result other
+This method adds a new connection to the cache.  As a result, other
 already cached connections might be dropped.  Multiple connections with
-the same $type/$key might added.
+the same type/key might be added.
 
-=item $conn = $cache->withdraw($type, $key)
+=head2 withdraw
+
+    my $conn = $cache->withdraw($type, $key);
 
 This method tries to fetch back a connection that was previously
 deposited.  If no cached connection with the specified $type/$key is
@@ -269,35 +303,35 @@ found, then C<undef> is returned.  There is not guarantee that a
 deposited connection can be withdrawn, as the cache manger is free to
 drop connections at any time.
 
-=back
+=head1 INTERNAL METHODS
 
 The following methods are called internally.  Subclasses might want to
 override them.
 
-=over
+=head2 enforce_limits
 
-=item $conn->enforce_limits([$type])
+    $conn->enforce_limits([$type])
 
 This method is called with after a new connection is added (deposited)
 in the cache or capacity limits are adjusted.  The default
 implementation drops connections until the specified capacity limits
 are not exceeded.
 
-=item $conn->dropping($conn_record, $reason)
+=head2 dropping
+
+    $conn->dropping($conn_record, $reason)
 
 This method is called when a connection is dropped.  The record
 belonging to the dropped connection is passed as the first argument
 and a string describing the reason for the drop is passed as the
 second argument.  The default implementation makes some noise if the
-$LWP::ConnCache::DEBUG variable is set and nothing more.
-
-=back
+C<$LWP::ConnCache::DEBUG> variable is set and nothing more.
 
 =head1 SUBCLASSING
 
 For specialized cache policy it makes sense to subclass
-C<LWP::ConnCache> and perhaps override the deposit(), enforce_limits()
-and dropping() methods.
+C<LWP::ConnCache> and perhaps override the L<LWP::ConnCache/deposit>,
+L<LWP::ConnCache/enforce_limits>, and L<LWP::ConnCache/dropping> methods.
 
 The object itself is a hash.  Keys prefixed with C<cc_> are reserved
 for the base class.

--- a/lib/LWP/MemberMixin.pm
+++ b/lib/LWP/MemberMixin.pm
@@ -21,8 +21,7 @@ LWP::MemberMixin - Member access mixin class
 =head1 SYNOPSIS
 
  package Foo;
- require LWP::MemberMixin;
- @ISA=qw(LWP::MemberMixin);
+ use base qw(LWP::MemberMixin);
 
 =head1 DESCRIPTION
 
@@ -30,18 +29,18 @@ A mixin class to get methods that provide easy access to member
 variables in the C<%$self>.
 Ideally there should be better Perl language support for this.
 
+=head1 METHODS
+
 There is only one method provided:
 
-=over 4
+=head2 _elem
 
-=item _elem($elem [, $val])
+    _elem($elem [, $val])
 
 Internal method to get/set the value of member variable
 C<$elem>. If C<$val> is present it is used as the new value
 for the member variable.  If it is not present the current
 value is not touched. In both cases the previous value of
 the member variable is returned.
-
-=back
 
 =cut

--- a/lib/LWP/Protocol.pm
+++ b/lib/LWP/Protocol.pm
@@ -202,8 +202,7 @@ LWP::Protocol - Base class for LWP protocols
 =head1 SYNOPSIS
 
  package LWP::Protocol::foo;
- require LWP::Protocol;
- @ISA=qw(LWP::Protocol);
+ use base qw(LWP::Protocol);
 
 =head1 DESCRIPTION
 
@@ -213,7 +212,7 @@ supported by the LWP library.
 When creating an instance of this class using
 C<LWP::Protocol::create($url)>, and you get an initialized subclass
 appropriate for that access method. In other words, the
-LWP::Protocol::create() function calls the constructor for one of its
+L<LWP::Protocol/create> function calls the constructor for one of its
 subclasses.
 
 All derived C<LWP::Protocol> classes need to override the request()
@@ -221,66 +220,75 @@ method which is used to service a request. The overridden method can
 make use of the collect() function to collect together chunks of data
 as it is received.
 
+=head1 METHODS
+
 The following methods and functions are provided:
 
-=over 4
+=head2 new
 
-=item $prot = LWP::Protocol->new()
+    my $prot = LWP::Protocol->new();
 
 The LWP::Protocol constructor is inherited by subclasses. As this is a
 virtual base class this method should B<not> be called directly.
 
-=item $prot = LWP::Protocol::create($scheme)
+=head2 create
+
+    my $prot = LWP::Protocol::create($scheme)
 
 Create an object of the class implementing the protocol to handle the
 given scheme. This is a function, not a method. It is more an object
 factory than a constructor. This is the function user agents should
 use to access protocols.
 
-=item $class = LWP::Protocol::implementor($scheme, [$class])
+=head2 implementor
 
-Get and/or set implementor class for a scheme.  Returns '' if the
+    my $class = LWP::Protocol::implementor($scheme, [$class])
+
+Get and/or set implementor class for a scheme.  Returns C<''> if the
 specified scheme is not supported.
 
-=item $prot->request(...)
+=head2 request
 
- $response = $protocol->request($request, $proxy, undef);
- $response = $protocol->request($request, $proxy, '/tmp/sss');
- $response = $protocol->request($request, $proxy, \&callback, 1024);
+    $response = $protocol->request($request, $proxy, undef);
+    $response = $protocol->request($request, $proxy, '/tmp/sss');
+    $response = $protocol->request($request, $proxy, \&callback, 1024);
 
 Dispatches a request over the protocol, and returns a response
 object. This method needs to be overridden in subclasses.  Refer to
 L<LWP::UserAgent> for description of the arguments.
 
-=item $prot->collect($arg, $response, $collector)
+=head2 collect
 
-Called to collect the content of a request, and process it
-appropriately into a scalar, file, or by calling a callback.  If $arg
-is undefined, then the content is stored within the $response.  If
-$arg is a simple scalar, then $arg is interpreted as a file name and
-the content is written to this file.  If $arg is a reference to a
-routine, then content is passed to this routine.
+    my $res = $prot->collect(undef, $response, $collector); # stored in $response
+    my $res = $prot->collect($filename, $response, $collector);
+    my $res = $prot->collect(sub { ... }, $response, $collector);
 
-The $collector is a routine that will be called and which is
+Collect the content of a request, and process it appropriately into a scalar,
+file, or by calling a callback. If the first parameter is undefined, then the
+content is stored within the C<$response>. If it's a simple scalar, then it's
+interpreted as a file name and the content is written to this file.  If it's a
+code reference, then content is passed to this routine.
+
+The collector is a routine that will be called and which is
 responsible for returning pieces (as ref to scalar) of the content to
-process.  The $collector signals EOF by returning a reference to an
+process.  The C<$collector> signals C<EOF> by returning a reference to an
 empty string.
 
-The return value from collect() is the $response object reference.
+The return value is the L<HTTP::Response> object reference.
 
 B<Note:> We will only use the callback or file argument if
-$response->is_success().  This avoids sending content data for
+C<< $response->is_success() >>.  This avoids sending content data for
 redirects and authentication responses to the callback which would be
 confusing.
 
-=item $prot->collect_once($arg, $response, $content)
+=head2 collect_once
 
-Can be called when the whole response content is available as
-$content.  This will invoke collect() with a collector callback that
-returns a reference to $content the first time and an empty string the
+    $prot->collect_once($arg, $response, $content)
+
+Can be called when the whole response content is available as content. This
+will invoke L<LWP::Protocol/collect> with a collector callback that
+returns a reference to C<$content> the first time and an empty string the
 next.
-
-=back
 
 =head1 SEE ALSO
 

--- a/lib/LWP/RobotUA.pm
+++ b/lib/LWP/RobotUA.pm
@@ -215,7 +215,7 @@ should consult the F</robots.txt> file to ensure that they are welcomed
 and they should not make requests too frequently.
 
 But before you consider writing a robot, take a look at
-<URL:http://www.robotstxt.org/>.
+L<URL:http://www.robotstxt.org/>.
 
 When you use an I<LWP::RobotUA> object as your user agent, then you do not
 really have to think about these things yourself; C<robots.txt> files
@@ -228,16 +228,14 @@ special agent will make sure you are nice.
 
 =head1 METHODS
 
-The LWP::RobotUA is a sub-class of LWP::UserAgent and implements the
+The LWP::RobotUA is a sub-class of L<LWP::UserAgent> and implements the
 same methods. In addition the following methods are provided:
 
-=over 4
+=head2 new
 
-=item $ua = LWP::RobotUA->new( %options )
-
-=item $ua = LWP::RobotUA->new( $agent, $from )
-
-=item $ua = LWP::RobotUA->new( $agent, $from, $rules )
+    my $ua = LWP::RobotUA->new( %options )
+    my $ua = LWP::RobotUA->new( $agent, $from )
+    my $ua = LWP::RobotUA->new( $agent, $from, $rules )
 
 The LWP::UserAgent options C<agent> and C<from> are mandatory.  The
 options C<delay>, C<use_sleep> and C<rules> initialize attributes
@@ -248,50 +246,57 @@ F<robots.txt>.
 It is also possible to just pass the value of C<agent>, C<from> and
 optionally C<rules> as plain positional arguments.
 
-=item $ua->delay
+=head2 delay
 
-=item $ua->delay( $minutes )
+    my $delay = $ua->delay;
+    $ua->delay( $minutes );
 
 Get/set the minimum delay between requests to the same server, in
-I<minutes>.  The default is 1 minute.  Note that this number doesn't
-have to be an integer; for example, this sets the delay to 10 seconds:
+I<minutes>.  The default is C<1> minute.  Note that this number doesn't
+have to be an integer; for example, this sets the delay to C<10> seconds:
 
     $ua->delay(10/60);
 
-=item $ua->use_sleep
+=head2 use_sleep
 
-=item $ua->use_sleep( $boolean )
+    my $bool = $ua->use_sleep;
+    $ua->use_sleep( $boolean );
 
-Get/set a value indicating whether the UA should sleep() if requests
-arrive too fast, defined as $ua->delay minutes not passed since
-last request to the given server.  The default is TRUE.  If this value is
-FALSE then an internal SERVICE_UNAVAILABLE response will be generated.
-It will have a Retry-After header that indicates when it is OK to
+Get/set a value indicating whether the UA should L<LWP::RobotUA/sleep> if
+requests arrive too fast, defined as C<< $ua->delay >> minutes not passed since
+last request to the given server.  The default is true.  If this value is
+false then an internal C<SERVICE_UNAVAILABLE> response will be generated.
+It will have a C<Retry-After> header that indicates when it is OK to
 send another request to this server.
 
-=item $ua->rules
+=head2 rules
 
-=item $ua->rules( $rules )
+    my $rules = $ua->rules;
+    $ua->rules( $rules );
 
 Set/get which I<WWW::RobotRules> object to use.
 
-=item $ua->no_visits( $netloc )
+=head2 no_visits
+
+    my $num = $ua->no_visits( $netloc )
 
 Returns the number of documents fetched from this server host. Yeah I
-know, this method should probably have been named num_visits() or
+know, this method should probably have been named C<num_visits> or
 something like that. :-(
 
-=item $ua->host_wait( $netloc )
+=head2 host_wait
+
+    my $num = $ua->host_wait( $netloc )
 
 Returns the number of I<seconds> (from now) you must wait before you can
 make a new request to this host.
 
-=item $ua->as_string
+=head2 as_string
+
+    my $string = $ua->as_string;
 
 Returns a string that describes the state of the UA.
 Mainly useful for debugging.
-
-=back
 
 =head1 SEE ALSO
 

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -125,22 +125,34 @@ you need more control or access to the header fields in the requests
 sent and responses received, then you should use the full object-oriented
 interface provided by the L<LWP::UserAgent> module.
 
+The module will also export the L<LWP::UserAgent> object as C<$ua> if you
+ask for it explicitly.
+
+The user agent created by this module will identify itself as
+C<LWP::Simple/#.##>
+and will initialize its proxy defaults from the environment (by
+calling C<< $ua->env_proxy >>).
+
+=head1 FUNCTIONS
+
 The following functions are provided (and exported) by this module:
 
-=over 3
+=head2 get
 
-=item get($url)
+    my $res = get($url);
 
 The get() function will fetch the document identified by the given URL
-and return it.  It returns C<undef> if it fails.  The $url argument can
-be either a string or a reference to a URI object.
+and return it.  It returns C<undef> if it fails.  The C<$url> argument can
+be either a string or a reference to a L<URI> object.
 
 You will not be able to examine the response code or response headers
-(like 'Content-Type') when you are accessing the web using this
+(like C<Content-Type>) when you are accessing the web using this
 function.  If you need that information you should use the full OO
 interface (see L<LWP::UserAgent>).
 
-=item head($url)
+=head2 head
+
+    my $res = head($url);
 
 Get document headers. Returns the following 5 values if successful:
 ($content_type, $document_length, $modified_time, $expires, $server)
@@ -148,7 +160,9 @@ Get document headers. Returns the following 5 values if successful:
 Returns an empty list if it fails.  In scalar context returns TRUE if
 successful.
 
-=item getprint($url)
+=head2 getprint
+
+    my $code = getprint($url);
 
 Get and print a document identified by a URL. The document is printed
 to the selected default filehandle for output (normally STDOUT) as
@@ -156,22 +170,26 @@ data is received from the network.  If the request fails, then the
 status code and message are printed on STDERR.  The return value is
 the HTTP response code.
 
-=item getstore($url, $file)
+=head2 getstore
+
+    my $code = getstore($url, $file)
 
 Gets a document identified by a URL and stores it in the file. The
 return value is the HTTP response code.
 
-=item mirror($url, $file)
+=head2 mirror
+
+    my $code = mirror($url, $file);
 
 Get and store a document identified by a URL, using
 I<If-modified-since>, and checking the I<Content-Length>.  Returns
 the HTTP response code.
 
-=back
+=head1 STATUS CONSTANTS
 
-This module also exports the HTTP::Status constants and procedures.
-You can use them when you check the response code from getprint(),
-getstore() or mirror().  The constants are:
+This module also exports the L<HTTP::Status> constants and procedures.
+You can use them when you check the response code from L<LWP::Simple/getprint>,
+L<LWP::Simple/getstore> or L<LWP::Simple/mirror>.  The constants are:
 
    RC_CONTINUE
    RC_SWITCHING_PROTOCOLS
@@ -211,34 +229,28 @@ getstore() or mirror().  The constants are:
    RC_GATEWAY_TIMEOUT
    RC_HTTP_VERSION_NOT_SUPPORTED
 
-The HTTP::Status classification functions are:
+=head1 CLASSIFICATION FUNCTIONS
 
-=over 3
+The L<HTTP::Status> classification functions are:
 
-=item is_success($rc)
+=head2 is_success
+
+    my $bool = is_success($rc);
 
 True if response code indicated a successful request.
 
-=item is_error($rc)
+=head2 is_error
+
+    my $bool = is_error($rc)
 
 True if response code indicated that an error occurred.
 
-=back
-
-The module will also export the LWP::UserAgent object as C<$ua> if you
-ask for it explicitly.
-
-The user agent created by this module will identify itself as
-"LWP::Simple/#.##"
-and will initialize its proxy defaults from the environment (by
-calling $ua->env_proxy).
-
 =head1 CAVEAT
 
-Note that if you are using both LWP::Simple and the very popular CGI.pm
+Note that if you are using both LWP::Simple and the very popular L<CGI>
 module, you may be importing a C<head> function from each module,
-producing a warning like "Prototype mismatch: sub main::head ($) vs
-none". Get around this problem by just not importing LWP::Simple's
+producing a warning like C<Prototype mismatch: sub main::head ($) vs none>.
+Get around this problem by just not importing LWP::Simple's
 C<head> function, like so:
 
         use LWP::Simple qw(!head);

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1113,7 +1113,9 @@ LWP::UserAgent - Web user agent class
 
 =head1 SYNOPSIS
 
- require LWP::UserAgent;
+ use strict;
+ use warnings;
+ use LWP::UserAgent ();
 
  my $ua = LWP::UserAgent->new;
  $ua->timeout(10);
@@ -1139,24 +1141,26 @@ then creates an instance of L<HTTP::Request> for the request that
 needs to be performed. This request is then passed to one of the
 request method the UserAgent, which dispatches it using the relevant
 protocol, and returns a L<HTTP::Response> object.  There are
-convenience methods for sending the most common request types: get(),
-head(), post(), put() and delete().  When using these methods then the
-creation of the request object is hidden as shown in the synopsis above.
+convenience methods for sending the most common request types:
+L<LWP::UserAgent/get>, L<LWP::UserAgent/head>, L<LWP::UserAgent/post>,
+L<LWP::UserAgent/put> and L<LWP::UserAgent/delete>.  When using these
+methods, the creation of the request object is hidden as shown in the
+synopsis above.
 
-The basic approach of the library is to use HTTP style communication
+The basic approach of the library is to use HTTP-style communication
 for all protocol schemes.  This means that you will construct
 L<HTTP::Request> objects and receive L<HTTP::Response> objects even
 for non-HTTP resources like I<gopher> and I<ftp>.  In order to achieve
-even more similarity to HTTP style communications, gopher menus and
+even more similarity to HTTP-style communications, I<gopher> menus and
 file directories are converted to HTML documents.
 
 =head1 CONSTRUCTOR METHODS
 
 The following constructor methods are available:
 
-=over 4
+=head2 new
 
-=item $ua = LWP::UserAgent->new( %options )
+    my $ua = LWP::UserAgent->new( %options )
 
 This method constructs a new L<LWP::UserAgent> object and returns it.
 Key/value pair arguments may be provided to set up the initial state.
@@ -1170,7 +1174,7 @@ The following options correspond to attribute methods described below:
    cookie_jar              undef
    default_headers         HTTP::Headers->new
    local_address           undef
-   ssl_opts		   { verify_hostname => 1 }
+   ssl_opts                { verify_hostname => 1 }
    max_size                undef
    max_redirect            7
    parse_head              1
@@ -1180,18 +1184,19 @@ The following options correspond to attribute methods described below:
    timeout                 180
 
 The following additional options are also accepted: If the C<env_proxy> option
-is passed in with a TRUE value, then proxy settings are read from environment
-variables (see env_proxy() method below).  If C<env_proxy> isn't provided the
-C<PERL_LWP_ENV_PROXY> environment variable controls if env_proxy() is called
-during initialization.  If the C<keep_alive> option is passed in, then a
-C<LWP::ConnCache> is set up (see conn_cache() method below).  The C<keep_alive>
-value is passed on as the C<total_capacity> for the connection cache.
+is passed in with a true value, then proxy settings are read from environment
+variables (see L<LWP::UserAgent/env_proxy>). If C<env_proxy> isn't provided, the
+C<PERL_LWP_ENV_PROXY> environment variable controls if
+L<LWP::UserAgent/env_proxy> is called during initialization.  If the
+C<keep_alive> option is passed in, then a C<LWP::ConnCache> is set up (see
+L<LWP::UserAgent/conn_cache>).  The C<keep_alive> value is passed on as the
+C<total_capacity> for the connection cache.
 
-=item $ua->clone
+=head2 clone
 
-Returns a copy of the LWP::UserAgent object.
+    my $ua2 = $ua->clone;
 
-=back
+Returns a copy of the L<LWP::UserAgent> object.
 
 =head1 ATTRIBUTES
 
@@ -1203,67 +1208,66 @@ The following attribute methods are provided.  The attribute value is
 left unchanged if no argument is given.  The return value from each
 method is the old attribute value.
 
-=over
+=head2 _agent
 
-=item $ua->agent
-
-=item $ua->agent( $product_id )
-
-Get/set the product token that is used to identify the user agent on
-the network.  The agent value is sent as the "User-Agent" header in
-the requests.  The default is the string returned by the _agent()
-method (see below).
-
-If the $product_id ends with space then the _agent() string is
-appended to it.
-
-The user agent string should be one or more simple product identifiers
-with an optional version number separated by the "/" character.
-Examples are:
-
-  $ua->agent('Checkbot/0.4 ' . $ua->_agent);
-  $ua->agent('Checkbot/0.4 ');    # same as above
-  $ua->agent('Mozilla/5.0');
-  $ua->agent("");                 # don't identify
-
-=item $ua->_agent
+    my $agent_string = $ua->_agent;
 
 Returns the default agent identifier.  This is a string of the form
-"libwww-perl/#.###", where "#.###" is substituted with the version number
+C<libwww-perl/#.###>, where C<#.###> is substituted with the version number
 of this library.
 
-=item $ua->from
+=head2 agent
 
-=item $ua->from( $email_address )
+    my $agent = $ua->agent;
+    $ua->agent( $product_id );
+    $ua->agent('Checkbot/0.4 ' . $ua->_agent);
+    $ua->agent('Checkbot/0.4 ');    # same as above
+    $ua->agent('Mozilla/5.0');
+    $ua->agent("");                 # don't identify
 
-Get/set the e-mail address for the human user who controls
+Get/set the product token that is used to identify the user agent on
+the network.  The agent value is sent as the C<User-Agent> header in
+the requests.  The default is the string returned by the
+L<LWP::UserAgent/_agent> method.
+
+If the C<$product_id> ends with space then the L<LWP::UserAgent/_agent> string
+is appended to it.
+
+The user agent string should be one or more simple product identifiers
+with an optional version number separated by the C</> character.
+
+=head2 from
+
+    my $from = $ua->from;
+    $ua->from('foo@bar.com');
+
+Get/set the email address for the human user who controls
 the requesting user agent.  The address should be machine-usable, as
-defined in RFC 822.  The C<from> value is send as the "From" header in
-the requests.  Example:
+defined in L<RFC2822|https://tools.ietf.org/html/rfc2822>. The C<from> value
+is sent as the C<From> header in the requests.
 
-  $ua->from('gaas@cpan.org');
+The default is to not send a C<From> header.  See
+L<LWP::UserAgent/default_headers> for the more general interface that allow
+any header to be defaulted.
 
-The default is to not send a "From" header.  See the default_headers()
-method for the more general interface that allow any header to be defaulted.
+=head2 cookie_jar
 
-=item $ua->cookie_jar
-
-=item $ua->cookie_jar( $cookie_jar_obj )
+    my $jar = $ua->cookie_jar;
+    $ua->cookie_jar( $cookie_jar_obj );
 
 Get/set the cookie jar object to use.  The only requirement is that
-the cookie jar object must implement the extract_cookies($response) and
-add_cookie_header($request) methods.  These methods will then be
+the cookie jar object must implement the C<extract_cookies($response)> and
+C<add_cookie_header($request)> methods.  These methods will then be
 invoked by the user agent as requests are sent and responses are
 received.  Normally this will be a L<HTTP::Cookies> object or some
 subclass.
 
-The default is to have no cookie_jar, i.e. never automatically add
-"Cookie" headers to the requests.
+The default is to have no cookie jar, i.e. never automatically add
+C<Cookie> headers to the requests.
 
-Shortcut: If a reference to a plain hash is passed in as the
-$cookie_jar_object, then it is replaced with an instance of
-L<HTTP::Cookies> that is initialized based on the hash.  This form also
-automatically loads the L<HTTP::Cookies> module.  It means that:
+Shortcut: If a reference to a plain hash is passed in, it is replaced with an
+instance of L<HTTP::Cookies> that is initialized based on the hash. This form
+also automatically loads the L<HTTP::Cookies> module.  It means that:
 
   $ua->cookie_jar({ file => "$ENV{HOME}/.cookies.txt" });
 
@@ -1272,86 +1276,99 @@ is really just a shortcut for:
   require HTTP::Cookies;
   $ua->cookie_jar(HTTP::Cookies->new(file => "$ENV{HOME}/.cookies.txt"));
 
-=item $ua->default_headers
+=head2 default_headers
 
-=item $ua->default_headers( $headers_obj )
+    my $headers = $ua->default_headers;
+    $ua->default_headers( $headers_obj );
 
 Get/set the headers object that will provide default header values for
 any requests sent.  By default this will be an empty L<HTTP::Headers>
 object.
 
-=item $ua->default_header( $field )
+=head2 default_header
 
-=item $ua->default_header( $field => $value )
+    $ua->default_header( $field );
+    $ua->default_header( $field => $value );
+    $ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
+    $ua->default_header('Accept-Language' => "no, en");
 
-This is just a short-cut for $ua->default_headers->header( $field =>
-$value ). Example:
+This is just a shortcut for
+C<< $ua->default_headers->header( $field => $value ) >>.
 
-  $ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
-  $ua->default_header('Accept-Language' => "no, en");
+=head2 conn_cache
 
-=item $ua->conn_cache
-
-=item $ua->conn_cache( $cache_obj )
+    my $cache_obj = $ua->conn_cache;
+    $ua->conn_cache( $cache_obj );
 
 Get/set the L<LWP::ConnCache> object to use.  See L<LWP::ConnCache>
 for details.
 
-=item $ua->credentials( $netloc, $realm )
+=head2 credentials
 
-=item $ua->credentials( $netloc, $realm, $uname, $pass )
+    my $creds = $ua->credentials();
+    $ua->credentials( $netloc, $realm );
+    $ua->credentials( $netloc, $realm, $uname, $pass );
+    $ua->credentials("www.example.com:80", "Some Realm", "foo", "secret");
 
 Get/set the user name and password to be used for a realm.
 
-The $netloc is a string of the form "<host>:<port>".  The username and
-password will only be passed to this server.  Example:
+The C<$netloc> is a string of the form C<< <host>:<port> >>.  The username and
+password will only be passed to this server.
 
-  $ua->credentials("www.example.com:80", "Some Realm", "foo", "secret");
+=head2 local_address
 
-=item $ua->local_address
-
-=item $ua->local_address( $address )
+    my $address = $ua->local_address;
+    $ua->local_address( $address );
 
 Get/set the local interface to bind to for network connections.  The interface
 can be specified as a hostname or an IP address.  This value is passed as the
 C<LocalAddr> argument to L<IO::Socket::INET>.
 
-=item $ua->max_size
+=head2 max_size
 
-=item $ua->max_size( $bytes )
+    my $size = $ua->max_size;
+    $ua->max_size( $bytes );
 
 Get/set the size limit for response content.  The default is C<undef>,
 which means that there is no limit.  If the returned response content
 is only partial, because the size limit was exceeded, then a
-"Client-Aborted" header will be added to the response.  The content
+C<Client-Aborted> header will be added to the response.  The content
 might end up longer than C<max_size> as we abort once appending a
-chunk of data makes the length exceed the limit.  The "Content-Length"
+chunk of data makes the length exceed the limit.  The C<Content-Length>
 header, if present, will indicate the length of the full content and
 will normally not be the same as C<< length($res->content) >>.
 
-=item $ua->max_redirect
+=head2 max_redirect
 
-=item $ua->max_redirect( $n )
+    my $max = $ua->max_redirect;
+    $ua->max_redirect( $n );
 
 This reads or sets the object's limit of how many times it will obey
 redirection responses in a given request cycle.
 
-By default, the value is 7. This means that if you call request()
-method and the response is a redirect elsewhere which is in turn a
+By default, the value is C<7>. This means that if you call L<LWP::UserAgent/request>
+and the response is a redirect elsewhere which is in turn a
 redirect, and so on seven times, then LWP gives up after that seventh
 request.
 
-=item $ua->parse_head
+=head2 parse_head
 
-=item $ua->parse_head( $boolean )
+    my $bool = $ua->parse_head;
+    $ua->parse_head( $boolean );
 
 Get/set a value indicating whether we should initialize response
 headers from the E<lt>head> section of HTML documents. The default is
-TRUE.  Do not turn this off, unless you know what you are doing.
+true. I<Do not turn this off> unless you know what you are doing.
 
-=item $ua->protocols_allowed
+=head2 protocols_allowed
 
-=item $ua->protocols_allowed( \@protocols )
+    my $aref = $ua->protocols_allowed;      # get allowed protocols
+    $ua->protocols_allowed( \@protocols );  # allow ONLY these
+    $ua->protocols_allowed(undef);          # delete the list
+    $ua->protocols_allowed(['http',]);      # ONLY allow http
+
+By default, an object has neither a C<protocols_allowed> list, nor a
+L<LWP::UserAgent/protocols_forbidden> list.
 
 This reads (or sets) this user agent's list of protocols that the
 request methods will exclusively allow.  The protocol names are case
@@ -1360,19 +1377,17 @@ insensitive.
 For example: C<< $ua->protocols_allowed( [ 'http', 'https'] ); >>
 means that this user agent will I<allow only> those protocols,
 and attempts to use this user agent to access URLs with any other
-schemes (like "ftp://...") will result in a 500 error.
-
-To delete the list, call: C<< $ua->protocols_allowed(undef) >>
-
-By default, an object has neither a C<protocols_allowed> list, nor a
-C<protocols_forbidden> list.
+schemes (like C<ftp://...>) will result in a 500 error.
 
 Note that having a C<protocols_allowed> list causes any
-C<protocols_forbidden> list to be ignored.
+L<LWP::UserAgent/protocols_forbidden> list to be ignored.
 
-=item $ua->protocols_forbidden
+=head2 protocols_forbidden
 
-=item $ua->protocols_forbidden( \@protocols )
+    my $aref = $ua->protocols_forbidden;    # get the forbidden list
+    $ua->protocols_forbidden(\@protocols);  # do not allow these
+    $ua->protocols_forbidden(['http',]);    # All http reqs get a 500
+    $ua->protocols_forbidden(undef);        # delete the list
 
 This reads (or sets) this user agent's list of protocols that the
 request method will I<not> allow. The protocol names are case
@@ -1383,43 +1398,45 @@ means that this user agent will I<not> allow those protocols, and
 attempts to use this user agent to access URLs with those schemes
 will result in a 500 error.
 
-To delete the list, call: C<< $ua->protocols_forbidden(undef) >>
+=head2 requests_redirectable
 
-=item $ua->requests_redirectable
-
-=item $ua->requests_redirectable( \@requests )
+    my $aref = $ua->requests_redirectable;
+    $ua->requests_redirectable( \@requests );
+    $ua->requests_redirectable(['GET', 'HEAD',]); # the default
 
 This reads or sets the object's list of request names that
-C<< $ua->redirect_ok(...) >> will allow redirection for.  By
-default, this is C<['GET', 'HEAD']>, as per RFC 2616.  To
-change to include 'POST', consider:
+L<LWP::UserAgent/redirect_ok> will allow redirection for. By default, this
+is C<['GET', 'HEAD']>, as per L<RFC 2616|https://tools.ietf.org/html/rfc2616>.
+To change to include C<POST>, consider:
 
    push @{ $ua->requests_redirectable }, 'POST';
 
-=item $ua->show_progress
+=head2 show_progress
 
-=item $ua->show_progress( $boolean )
+    my $bool = $ua->show_progress;
+    $ua->show_progress( $boolean );
 
 Get/set a value indicating whether a progress bar should be displayed
-on the terminal as requests are processed. The default is FALSE.
+on the terminal as requests are processed. The default is false.
 
-=item $ua->timeout
+=head2 timeout
 
-=item $ua->timeout( $secs )
+    my $secs = $ua->timeout;
+    $ua->timeout( $secs );
 
-Get/set the timeout value in seconds. The default timeout() value is
+Get/set the timeout value in seconds. The default value is
 180 seconds, i.e. 3 minutes.
 
 The requests is aborted if no activity on the connection to the server
 is observed for C<timeout> seconds.  This means that the time it takes
-for the complete transaction and the request() method to actually
-return might be longer.
+for the complete transaction and the L<LWP::UserAgent/request> method to
+actually return might be longer.
 
-=item $ua->ssl_opts
+=head2 ssl_opts
 
-=item $ua->ssl_opts( $key )
-
-=item $ua->ssl_opts( $key => $value )
+    my @keys = $ua->ssl_opts;
+    my $val = $ua->ssl_opts( $key );
+    $ua->ssl_opts( $key => $value );
 
 Get/set the options for SSL connections.  Without argument return the list
 of options keys currently set.  With a single argument return the current
@@ -1463,41 +1480,42 @@ The libwww-perl core no longer bundles protocol plugins for SSL.  You will need
 to install L<LWP::Protocol::https> separately to enable support for processing
 https-URLs.
 
-=back
-
-=head2 Proxy attributes
+=head1 Proxy attributes
 
 The following methods set up when requests should be passed via a
 proxy server.
 
-=over
+=head2 proxy
 
-=item $ua->proxy(\@schemes, $proxy_url)
+    $ua->proxy(\@schemes, $proxy_url)
+    $ua->proxy(['http', 'ftp'], 'http://proxy.sn.no:8001/');
+    # or, for a single scheme
+    $ua->proxy($scheme, $proxy_url)
+    $ua->proxy('gopher', 'http://proxy.sn.no:8001/');
 
-=item $ua->proxy($scheme, $proxy_url)
-
-Set/retrieve proxy URL for a scheme:
-
- $ua->proxy(['http', 'ftp'], 'http://proxy.sn.no:8001/');
- $ua->proxy('gopher', 'http://proxy.sn.no:8001/');
+Set/retrieve proxy URL for a scheme.
 
 The first form specifies that the URL is to be used as a proxy for
 access methods listed in the list in the first method argument,
-i.e. 'http' and 'ftp'.
+i.e. C<http> and C<ftp>.
 
 The second form shows a shorthand form for specifying
 proxy URL for a single access scheme.
 
-=item $ua->no_proxy( $domain, ... )
+=head2 no_proxy
 
-Do not proxy requests to the given domains.  Calling no_proxy without
-any domains clears the list of domains. For example:
+    $ua->no_proxy( @domains );
+    $ua->no_proxy('localhost', 'example.com');
+    $ua->no_proxy(); # clear the list
 
- $ua->no_proxy('localhost', 'example.com');
+Do not proxy requests to the given domains.  Calling C<no_proxy> without
+any domains clears the list of domains.
 
-=item $ua->env_proxy
+=head2 env_proxy
 
-Load proxy settings from *_proxy environment variables.  You might
+    $ua->env_proxy;
+
+Load proxy settings from C<*_proxy> environment variables.  You might
 specify proxies like this (sh-syntax):
 
   gopher_proxy=http://proxy.my.place/
@@ -1510,26 +1528,24 @@ environment variables.
 
 On systems with case insensitive environment variables there exists a
 name clash between the CGI environment variables and the C<HTTP_PROXY>
-environment variable normally picked up by env_proxy().  Because of
+environment variable normally picked up by C<env_proxy>.  Because of
 this C<HTTP_PROXY> is not honored for CGI scripts.  The
 C<CGI_HTTP_PROXY> environment variable can be used instead.
 
-=back
-
-=head2 Handlers
+=head1 Handlers
 
 Handlers are code that injected at various phases during the
 processing of requests.  The following methods are provided to manage
 the active handlers:
 
-=over
+=head2 add_handler
 
-=item $ua->add_handler( $phase => \&cb, %matchspec )
+    $ua->add_handler( $phase => \&cb, %matchspec )
 
 Add handler to be invoked in the given processing phase.  For how to
-specify %matchspec see L<HTTP::Config/"Matching">.
+specify C<%matchspec> see L<HTTP::Config/"Matching">.
 
-The possible values $phase and the corresponding callback signatures are:
+The possible values C<$phase> and the corresponding callback signatures are:
 
 =over
 
@@ -1596,47 +1612,52 @@ this request instead.
 
 =back
 
-=item $ua->remove_handler( undef, %matchspec )
+=head2 remove_handler
 
-=item $ua->remove_handler( $phase, %matchspec )
+    $ua->remove_handler( undef, %matchspec );
+    $ua->remove_handler( $phase, %matchspec );
+    $ua->remove_handlers(); # REMOVE ALL HANDLERS IN ALL PHASES
 
-Remove handlers that match the given %matchspec.  If $phase is not
-provided remove handlers from all phases.
+Remove handlers that match the given C<%matchspec>.  If C<$phase> is not
+provided, remove handlers from all phases.
 
-Be careful as calling this function with %matchspec that is not
+Be careful as calling this function with C<%matchspec> that is not
 specific enough can remove handlers not owned by you.  It's probably
-better to use the set_my_handler() method instead.
+better to use the L<LWP::UserAgent/set_my_handler> method instead.
 
 The removed handlers are returned.
 
-=item $ua->set_my_handler( $phase, $cb, %matchspec )
+=head2 set_my_handler
+
+    $ua->set_my_handler( $phase, $cb, %matchspec );
+    $ua->set_my_handler($phase, undef); # remove handler for phase
 
 Set handlers private to the executing subroutine.  Works by defaulting
-an C<owner> field to the %matchspec that holds the name of the called
+an C<owner> field to the C<%matchspec> that holds the name of the called
 subroutine.  You might pass an explicit C<owner> to override this.
 
 If $cb is passed as C<undef>, remove the handler.
 
-=item $ua->get_my_handler( $phase, %matchspec )
+=head2 get_my_handler
 
-=item $ua->get_my_handler( $phase, %matchspec, $init )
+    $ua->get_my_handler( $phase, %matchspec );
+    $ua->get_my_handler( $phase, %matchspec, $init );
 
 Will retrieve the matching handler as hash ref.
 
-If C<$init> is passed as a TRUE value, create and add the
-handler if it's not found.  If $init is a subroutine reference, then
+If C<$init> is passed as a true value, create and add the
+handler if it's not found.  If C<$init> is a subroutine reference, then
 it's called with the created handler hash as argument.  This sub might
 populate the hash with extra fields; especially the callback.  If
-$init is a hash reference, merge the hashes.
+C<$init> is a hash reference, merge the hashes.
 
-=item $ua->handlers( $phase, $request )
+=head2 handlers
 
-=item $ua->handlers( $phase, $response )
+    $ua->handlers( $phase, $request )
+    $ua->handlers( $phase, $response )
 
 Returns the handlers that apply to the given request or response at
 the given processing phase.
-
-=back
 
 =head1 REQUEST METHODS
 


### PR DESCRIPTION
Update all documentation in all modules (where documentation already exists) to move individual methods/functions/attributes up to the ```=head2``` level.  No longer have an item for each way to the call the function, but rather have those as example code below the new heading.

Try to have examples that more accurately describe how the functions work.  A lot more cleaning needs to be done and alphabetizing the lists needs to happen, but I think this is a good first step.

