### PR TITLE
warn() when Content-Length exceeds the actual payload length.

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -422,6 +422,12 @@ sub request {
         }
         return $response;
     }
+
+    my $content_length = $response->header('content-length');
+    if (defined $content_length && (length($response->{'_content'}) > $content_length)) {
+        warn sprintf( "'Content-Length' header (%d) exceeds the delivered payload length (%d)!", $content_length, length($response->{'_content'}) );
+    }
+
     return $response;
 }
 


### PR DESCRIPTION
Issue #86: This matches the behavior described in the last
paragraph of RFC 2616, section 4.4.