### PR TITLE
use strict and warnings in all bin files and perltidy them

### DIFF
--- a/bin/lwp-download
+++ b/bin/lwp-download
@@ -59,7 +59,7 @@ use strict;
 
 use LWP::UserAgent ();
 use LWP::MediaTypes qw(guess_media_type media_suffix);
-use URI ();
+use URI        ();
 use HTTP::Date ();
 use Encode;
 use Encode::Locale;
@@ -67,7 +67,7 @@ use Encode::Locale;
 my $progname = $0;
 $progname =~ s,.*/,,;    # only basename left in progname
 $progname =~ s,.*\\,, if $^O eq "MSWin32";
-$progname =~ s/\.\w*$//; # strip extension if any
+$progname =~ s/\.\w*$//;    # strip extension if any
 
 #parse option
 use Getopt::Std;
@@ -81,184 +81,191 @@ my $argfile = encode(locale_fs => decode(locale => shift));
 usage() if defined($argfile) && !length($argfile);
 
 my $ua = LWP::UserAgent->new(
-   agent => "lwp-download/$LWP::UserAgent::VERSION ",
-   keep_alive => 1,
-   env_proxy => 1,
+    agent      => "lwp-download/$LWP::UserAgent::VERSION ",
+    keep_alive => 1,
+    env_proxy  => 1,
 );
 
-my $file;      # name of file we download into
-my $length;    # total number of bytes to download
-my $flength;   # formatted length
-my $size = 0;  # number of bytes received
-my $start_t;   # start time of download
-my $last_dur;  # time of last callback
+my $file;       # name of file we download into
+my $length;     # total number of bytes to download
+my $flength;    # formatted length
+my $size = 0;   # number of bytes received
+my $start_t;    # start time of download
+my $last_dur;   # time of last callback
 
-my $shown = 0; # have we called the show() function yet
+my $shown = 0;  # have we called the show() function yet
 
 $SIG{INT} = sub { die "Interrupted\n"; };
 
-$| = 1;  # autoflush
+$| = 1;         # autoflush
 
-my $res = $ua->request(HTTP::Request->new(GET => $url),
-  sub {
-      unless(defined $file) {
-	  my $res = $_[1];
+my $res = $ua->request(
+    HTTP::Request->new(GET => $url),
+    sub {
+        unless (defined $file) {
+            my $res = $_[1];
 
-	  my $directory;
-	  if (defined $argfile && -d $argfile) {
-	      ($directory, $argfile) = ($argfile, undef);
-	  }
+            my $directory;
+            if (defined $argfile && -d $argfile) {
+                ($directory, $argfile) = ($argfile, undef);
+            }
 
-	  unless (defined $argfile) {
-	      # find a suitable name to use
-	      $file = $opt{s} && $res->filename;
+            unless (defined $argfile) {
 
-	      # if this fails we try to make something from the URL
-	      unless ($file) {
-		  $file = ($url->path_segments)[-1];
-		  if (!defined($file) || !length($file)) {
-		      $file = "index";
-		      my $suffix = media_suffix($res->content_type);
-		      $file .= ".$suffix" if $suffix;
-		  }
-		  elsif ($url->scheme eq 'ftp' ||
-			   $file =~ /\.t[bg]z$/   ||
-			   $file =~ /\.tar(\.(Z|gz|bz2?))?$/
-			  ) {
-		      # leave the filename as it was
-		  }
-		  else {
-		      my $ct = guess_media_type($file);
-		      unless ($ct eq $res->content_type) {
-			  # need a better suffix for this type
-			  my $suffix = media_suffix($res->content_type);
-			  $file .= ".$suffix" if $suffix;
-		      }
-		  }
-	      }
+                # find a suitable name to use
+                $file = $opt{s} && $res->filename;
 
-	      # validate that we don't have a harmful filename now.  The server
-	      # might try to trick us into doing something bad.
-	      if (!length($file) ||
-                  $file =~ s/([^a-zA-Z0-9_\.\-\+\~])/sprintf "\\x%02x", ord($1)/ge ||
-		  $file =~ /^\./
-	      )
-              {
-		  die "Will not save <$url> as \"$file\".\nPlease override file name on the command line.\n";
-	      }
+                # if this fails we try to make something from the URL
+                unless ($file) {
+                    $file = ($url->path_segments)[-1];
+                    if (!defined($file) || !length($file)) {
+                        $file = "index";
+                        my $suffix = media_suffix($res->content_type);
+                        $file .= ".$suffix" if $suffix;
+                    }
+                    elsif ($url->scheme eq 'ftp'
+                        || $file =~ /\.t[bg]z$/
+                        || $file =~ /\.tar(\.(Z|gz|bz2?))?$/)
+                    {
+                        # leave the filename as it was
+                    }
+                    else {
+                        my $ct = guess_media_type($file);
+                        unless ($ct eq $res->content_type) {
 
-	      if (defined $directory) {
-	          require File::Spec;
-	          $file = File::Spec->catfile($directory, $file);
-	      }
+                            # need a better suffix for this type
+                            my $suffix = media_suffix($res->content_type);
+                            $file .= ".$suffix" if $suffix;
+                        }
+                    }
+                }
 
-	      # Check if the file is already present
-	      if (-l $file) {
-		  die "Will not save <$url> to link \"$file\".\nPlease override file name on the command line.\n";
-	      }
-	      elsif (-f _) {
-		  die "Will not save <$url> as \"$file\" without verification.\nEither run from terminal or override file name on the command line.\n"
-		      unless -t;
-		  $shown = 1;
-		  print "Overwrite $file? [y] ";
-		  my $ans = <STDIN>;
-		  unless (defined($ans) && $ans =~ /^y?\n/) {
-		      if (defined $ans) {
-			  print "Ok, aborting.\n";
-		      }
-		      else {
-			  print "\nAborting.\n";
-		      }
-		      exit 1;
-		  }
-		  $shown = 0;
-	      }
-	      elsif (-e _) {
-		  die "Will not save <$url> as \"$file\".  Path exists.\n";
-	      }
-	      else {
-		  print "Saving to '$file'...\n";
-		  use Fcntl qw(O_WRONLY O_EXCL O_CREAT);
-		  sysopen(FILE, $file, O_WRONLY|O_EXCL|O_CREAT) ||
-		      die "Can't open $file: $!";
-	      }
-	  }
-	  else {
-	      $file = $argfile;
-	  }
-	  unless (fileno(FILE)) {
-	      open(FILE, ">", $file) || die "Can't open $file: $!\n";
-	  }
-          binmode FILE unless $opt{a};
-	  $length = $res->content_length;
-	  $flength = fbytes($length) if defined $length;
-	  $start_t = time;
-	  $last_dur = 0;
-      }
+               # validate that we don't have a harmful filename now.  The server
+               # might try to trick us into doing something bad.
+                if (!length($file)
+                    || $file
+                    =~ s/([^a-zA-Z0-9_\.\-\+\~])/sprintf "\\x%02x", ord($1)/ge
+                    || $file =~ /^\./)
+                {
+                    die
+                        "Will not save <$url> as \"$file\".\nPlease override file name on the command line.\n";
+                }
 
-      print FILE $_[0] or die "Can't write to $file: $!\n";
-      $size += length($_[0]);
+                if (defined $directory) {
+                    require File::Spec;
+                    $file = File::Spec->catfile($directory, $file);
+                }
 
-      if (defined $length) {
-	  my $dur  = time - $start_t;
-	  if ($dur != $last_dur) {  # don't update too often
-	      $last_dur = $dur;
-	      my $perc = $size / $length;
-	      my $speed;
-	      $speed = fbytes($size/$dur) . "/sec" if $dur > 3;
-	      my $secs_left = fduration($dur/$perc - $dur);
-	      $perc = int($perc*100);
-	      my $show = "$perc% of $flength";
-	      $show .= " (at $speed, $secs_left remaining)" if $speed;
-	      show($show, 1);
-	  }
-      }
-      else {
-	  show( fbytes($size) . " received");
-      }
-  }
+                # Check if the file is already present
+                if (-l $file) {
+                    die
+                        "Will not save <$url> to link \"$file\".\nPlease override file name on the command line.\n";
+                }
+                elsif (-f _) {
+                    die
+                        "Will not save <$url> as \"$file\" without verification.\nEither run from terminal or override file name on the command line.\n"
+                        unless -t;
+                    $shown = 1;
+                    print "Overwrite $file? [y] ";
+                    my $ans = <STDIN>;
+                    unless (defined($ans) && $ans =~ /^y?\n/) {
+                        if (defined $ans) {
+                            print "Ok, aborting.\n";
+                        }
+                        else {
+                            print "\nAborting.\n";
+                        }
+                        exit 1;
+                    }
+                    $shown = 0;
+                }
+                elsif (-e _) {
+                    die "Will not save <$url> as \"$file\".  Path exists.\n";
+                }
+                else {
+                    print "Saving to '$file'...\n";
+                    use Fcntl qw(O_WRONLY O_EXCL O_CREAT);
+                    sysopen(FILE, $file, O_WRONLY | O_EXCL | O_CREAT)
+                        || die "Can't open $file: $!";
+                }
+            }
+            else {
+                $file = $argfile;
+            }
+            unless (fileno(FILE)) {
+                open(FILE, ">", $file) || die "Can't open $file: $!\n";
+            }
+            binmode FILE unless $opt{a};
+            $length   = $res->content_length;
+            $flength  = fbytes($length) if defined $length;
+            $start_t  = time;
+            $last_dur = 0;
+        }
+
+        print FILE $_[0] or die "Can't write to $file: $!\n";
+        $size += length($_[0]);
+
+        if (defined $length) {
+            my $dur = time - $start_t;
+            if ($dur != $last_dur) {    # don't update too often
+                $last_dur = $dur;
+                my $perc = $size / $length;
+                my $speed;
+                $speed = fbytes($size / $dur) . "/sec" if $dur > 3;
+                my $secs_left = fduration($dur / $perc - $dur);
+                $perc = int($perc * 100);
+                my $show = "$perc% of $flength";
+                $show .= " (at $speed, $secs_left remaining)" if $speed;
+                show($show, 1);
+            }
+        }
+        else {
+            show(fbytes($size) . " received");
+        }
+    }
 );
 
 if (fileno(FILE)) {
     close(FILE) || die "Can't write to $file: $!\n";
 
-    show("");  # clear text
+    show("");    # clear text
     print "\r";
     print fbytes($size);
     print " of ", fbytes($length) if defined($length) && $length != $size;
     print " received";
     my $dur = time - $start_t;
     if ($dur) {
-	my $speed = fbytes($size/$dur) . "/sec";
-	print " in ", fduration($dur), " ($speed)";
+        my $speed = fbytes($size / $dur) . "/sec";
+        print " in ", fduration($dur), " ($speed)";
     }
     print "\n";
 
     if (my $mtime = $res->last_modified) {
-	utime time, $mtime, $file;
+        utime time, $mtime, $file;
     }
 
     if ($res->header("X-Died") || !$res->is_success) {
-	if (my $died = $res->header("X-Died")) {
-	    print "$died\n";
-	}
-	if (-t) {
-	    print "Transfer aborted.  Delete $file? [n] ";
-	    my $ans = <STDIN>;
-	    if (defined($ans) && $ans =~ /^y\n/) {
-		unlink($file) && print "Deleted.\n";
-	    }
-	    elsif ($length > $size) {
-		print "Truncated file kept: ", fbytes($length - $size), " missing\n";
-	    }
-	    else {
-		print "File kept.\n";
-	    }
+        if (my $died = $res->header("X-Died")) {
+            print "$died\n";
+        }
+        if (-t) {
+            print "Transfer aborted.  Delete $file? [n] ";
+            my $ans = <STDIN>;
+            if (defined($ans) && $ans =~ /^y\n/) {
+                unlink($file) && print "Deleted.\n";
+            }
+            elsif ($length > $size) {
+                print "Truncated file kept: ", fbytes($length - $size),
+                    " missing\n";
+            }
+            else {
+                print "File kept.\n";
+            }
             exit 1;
-	}
-	else {
-	    print "Transfer aborted, $file kept\n";
-	}
+        }
+        else {
+            print "Transfer aborted, $file kept\n";
+        }
     }
     exit 0;
 }
@@ -274,37 +281,35 @@ else {
 exit 1;
 
 
-sub fbytes
-{
+sub fbytes {
     my $n = int(shift);
     if ($n >= 1024 * 1024) {
-	return sprintf "%.3g MB", $n / (1024.0 * 1024);
+        return sprintf "%.3g MB", $n / (1024.0 * 1024);
     }
     elsif ($n >= 1024) {
-	return sprintf "%.3g KB", $n / 1024.0;
+        return sprintf "%.3g KB", $n / 1024.0;
     }
     else {
-	return "$n bytes";
+        return "$n bytes";
     }
 }
 
-sub fduration
-{
+sub fduration {
     use integer;
     my $secs = int(shift);
-    my $hours = $secs / (60*60);
-    $secs -= $hours * 60*60;
+    my $hours = $secs / (60 * 60);
+    $secs -= $hours * 60 * 60;
     my $mins = $secs / 60;
     $secs %= 60;
     if ($hours) {
-	return "$hours hours $mins minutes";
+        return "$hours hours $mins minutes";
     }
     elsif ($mins >= 2) {
-	return "$mins minutes";
+        return "$mins minutes";
     }
     else {
-	$secs += $mins * 60;
-	return "$secs seconds";
+        $secs += $mins * 60;
+        return "$secs seconds";
     }
 }
 
@@ -313,17 +318,15 @@ BEGIN {
     my @ani = qw(- \ | /);
     my $ani = 0;
 
-    sub show
-    {
-        my($mess, $show_ani) = @_;
+    sub show {
+        my ($mess, $show_ani) = @_;
         print "\r$mess" . (" " x (75 - length $mess));
-	print $show_ani ? "$ani[$ani++]\b" : " ";
+        print $show_ani ? "$ani[$ani++]\b" : " ";
         $ani %= @ani;
         $shown++;
     }
 }
 
-sub usage
-{
+sub usage {
     die "Usage: $progname [-a] <url> [<lpath>]\n";
 }

--- a/bin/lwp-download
+++ b/bin/lwp-download
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 =head1 NAME
 
@@ -56,6 +56,7 @@ Gisle Aas <gisle@aas.no>
 #' get emacs out of quote mode
 
 use strict;
+use warnings;
 
 use LWP::UserAgent ();
 use LWP::MediaTypes qw(guess_media_type media_suffix);
@@ -321,7 +322,8 @@ BEGIN {
     sub show {
         my ($mess, $show_ani) = @_;
         print "\r$mess" . (" " x (75 - length $mess));
-        print $show_ani ? "$ani[$ani++]\b" : " ";
+        my $msg = $show_ani ? $ani[$ani++]. "\b" : ' ';
+        print $msg;
         $ani %= @ani;
         $shown++;
     }

--- a/bin/lwp-dump
+++ b/bin/lwp-dump
@@ -1,6 +1,7 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 use strict;
+use warnings;
 use LWP::UserAgent ();
 use Getopt::Long qw(GetOptions);
 use Encode;

--- a/bin/lwp-dump
+++ b/bin/lwp-dump
@@ -6,14 +6,9 @@ use Getopt::Long qw(GetOptions);
 use Encode;
 use Encode::Locale;
 
-GetOptions(\my %opt,
-    'parse-head',
-    'max-length=n',
-    'keep-client-headers',
-    'method=s',
-    'agent=s',
-    'request',
-) || usage();
+GetOptions(\my %opt, 'parse-head', 'max-length=n', 'keep-client-headers',
+    'method=s', 'agent=s', 'request',)
+    || usage();
 
 my $url = shift || usage();
 @ARGV && usage();
@@ -37,15 +32,15 @@ EOT
 my $ua = LWP::UserAgent->new(
     parse_head => $opt{'parse-head'} || 0,
     keep_alive => 1,
-    env_proxy => 1,
-    agent => $opt{agent} || "lwp-dump/$LWP::UserAgent::VERSION ",
+    env_proxy  => 1,
+    agent      => $opt{agent}        || "lwp-dump/$LWP::UserAgent::VERSION ",
 );
 
 my $req = HTTP::Request->new($opt{method} || 'GET' => decode(locale => $url));
 my $res = $ua->simple_request($req);
 $res->remove_header(grep /^Client-/, $res->header_field_names)
-    unless $opt{'keep-client-headers'} or
-        ($res->header("Client-Warning") || "") eq "Internal response";
+    unless $opt{'keep-client-headers'}
+    or ($res->header("Client-Warning") || "") eq "Internal response";
 
 if ($opt{request}) {
     $res->request->dump;

--- a/bin/lwp-mirror
+++ b/bin/lwp-mirror
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 # Simple mirror utility using LWP
 
@@ -37,19 +37,20 @@ Gisle Aas <gisle@aas.no>
 
 =cut
 
-
+use strict;
+use warnings;
 use LWP::Simple qw(mirror is_success status_message $ua);
 use Getopt::Std;
 use Encode;
 use Encode::Locale;
 
-$progname = $0;
+my $progname = $0;
 $progname =~ s,.*/,,;       # use basename only
 $progname =~ s/\.\w*$//;    #strip extension if any
 
-$opt_h = undef;             # print usage
-$opt_v = undef;             # print version
-$opt_t = undef;             # timeout
+my $opt_h;             # print usage
+my $opt_v;             # print version
+my $opt_t;             # timeout
 
 unless (getopts("hvt:")) {
     usage();
@@ -68,20 +69,20 @@ modify it under the same terms as Perl itself.
 EOT
 }
 
-$url = decode(locale => shift) or usage();
-$file = encode(locale_fs => decode(locale => shift)) or usage();
+my $url = decode(locale => shift) or usage();
+my $file = encode(locale_fs => decode(locale => shift)) or usage();
 usage() if $opt_h or @ARGV;
 
 if (defined $opt_t) {
     $opt_t =~ /^(\d+)([smh])?/;
     die "$progname: Illegal timeout value!\n" unless defined $1;
-    $timeout = $1;
+    my $timeout = $1;
     $timeout *= 60   if ($2 eq "m");
     $timeout *= 3600 if ($2 eq "h");
     $ua->timeout($timeout);
 }
 
-$rc = mirror($url, $file);
+my $rc = mirror($url, $file);
 
 if ($rc == 304) {
     print STDERR "$progname: $file is up to date\n";

--- a/bin/lwp-mirror
+++ b/bin/lwp-mirror
@@ -44,12 +44,12 @@ use Encode;
 use Encode::Locale;
 
 $progname = $0;
-$progname =~ s,.*/,,;  # use basename only
-$progname =~ s/\.\w*$//; #strip extension if any
+$progname =~ s,.*/,,;       # use basename only
+$progname =~ s/\.\w*$//;    #strip extension if any
 
-$opt_h = undef;  # print usage
-$opt_v = undef;  # print version
-$opt_t = undef;  # timeout
+$opt_h = undef;             # print usage
+$opt_v = undef;             # print version
+$opt_t = undef;             # timeout
 
 unless (getopts("hvt:")) {
     usage();
@@ -68,7 +68,7 @@ modify it under the same terms as Perl itself.
 EOT
 }
 
-$url  = decode(locale => shift) or usage();
+$url = decode(locale => shift) or usage();
 $file = encode(locale_fs => decode(locale => shift)) or usage();
 usage() if $opt_h or @ARGV;
 
@@ -84,7 +84,7 @@ if (defined $opt_t) {
 $rc = mirror($url, $file);
 
 if ($rc == 304) {
-    print STDERR "$progname: $file is up to date\n"
+    print STDERR "$progname: $file is up to date\n";
 }
 elsif (!is_success($rc)) {
     print STDERR "$progname: $rc ", status_message($rc), "   ($url)\n";
@@ -93,8 +93,7 @@ elsif (!is_success($rc)) {
 exit;
 
 
-sub usage
-{
+sub usage {
     die <<"EOT";
 Usage: $progname [-options] <url> <file>
     -v           print version number of program

--- a/bin/lwp-request
+++ b/bin/lwp-request
@@ -181,8 +181,8 @@ Gisle Aas <gisle@aas.no>
 =cut
 
 $progname = $0;
-$progname =~ s,.*[\\/],,;  # use basename only
-$progname =~ s/\.\w*$//;   # strip extension, if any
+$progname =~ s,.*[\\/],,;    # use basename only
+$progname =~ s/\.\w*$//;     # strip extension, if any
 
 require LWP;
 
@@ -203,53 +203,52 @@ use HTTP::Date qw(time2str str2time);
 # "" = No content in request, "C" = Needs content in request
 #
 %allowed_methods = (
-    GET        => "",
-    HEAD       => "",
-    POST       => "C",
-    PUT        => "C",
-    DELETE     => "",
-    TRACE      => "",
-    OPTIONS    => "",
+    GET     => "",
+    HEAD    => "",
+    POST    => "C",
+    PUT     => "C",
+    DELETE  => "",
+    TRACE   => "",
+    OPTIONS => "",
 );
 
 
 # We make our own specialization of LWP::UserAgent that asks for
 # user/password if document is protected.
 {
+
     package RequestAgent;
-    
+
     use base qw(LWP::UserAgent);
 
-    sub new
-    {
-	my $self = LWP::UserAgent::new(@_);
-	$self->agent("lwp-request/$LWP::VERSION ");
-	$self;
+    sub new {
+        my $self = LWP::UserAgent::new(@_);
+        $self->agent("lwp-request/$LWP::VERSION ");
+        $self;
     }
 
-    sub get_basic_credentials
-    {
-	my($self, $realm, $uri) = @_;
-	if ($main::options{'C'}) {
-	    return split(':', $main::options{'C'}, 2);
-	}
-	elsif (-t) {
-	    my $netloc = $uri->host_port;
-	    print STDERR "Enter username for $realm at $netloc: ";
-	    my $user = <STDIN>;
-	    chomp($user);
-	    return (undef, undef) unless length $user;
-	    print STDERR "Password: ";
-	    system("stty -echo");
-	    my $password = <STDIN>;
-	    system("stty echo");
-	    print STDERR "\n";  # because we disabled echo
-	    chomp($password);
-	    return ($user, $password);
-	}
-	else {
-	    return (undef, undef)
-	}
+    sub get_basic_credentials {
+        my ($self, $realm, $uri) = @_;
+        if ($main::options{'C'}) {
+            return split(':', $main::options{'C'}, 2);
+        }
+        elsif (-t) {
+            my $netloc = $uri->host_port;
+            print STDERR "Enter username for $realm at $netloc: ";
+            my $user = <STDIN>;
+            chomp($user);
+            return (undef, undef) unless length $user;
+            print STDERR "Password: ";
+            system("stty -echo");
+            my $password = <STDIN>;
+            system("stty echo");
+            print STDERR "\n";    # because we disabled echo
+            chomp($password);
+            return ($user, $password);
+        }
+        else {
+            return (undef, undef);
+        }
     }
 }
 
@@ -259,31 +258,31 @@ $method = uc(lc($progname) eq "lwp-request" ? "GET" : $progname);
 use Getopt::Long;
 
 my @getopt_args = (
-    'a', # content i/o in text(ascii) mode
-    'm=s', # set method
-    'f', # make request even if method is not in %allowed_methods
-    'b=s', # base url
-    't=s', # timeout
-    'i=s', # if-modified-since
-    'c=s', # content type for POST
-    'C=s', # credentials for basic authorization
-    'H=s@', # extra headers, form "Header: value string"
-    #
-    'u', # display method and URL of request
-    'U', # display request headers also
-    's', # display status code
-    'S', # display whole chain of status codes
-    'e', # display response headers (default for HEAD)
-    'E', # display whole chain of headers
-    'd', # don't display content
-    #
-    'h', # print usage
-    'v', # print version
-    #
-    'p=s', # proxy URL
-    'P', # don't load proxy setting from environment
-    #
-    'o=s', # output format
+    'a',       # content i/o in text(ascii) mode
+    'm=s',     # set method
+    'f',       # make request even if method is not in %allowed_methods
+    'b=s',     # base url
+    't=s',     # timeout
+    'i=s',     # if-modified-since
+    'c=s',     # content type for POST
+    'C=s',     # credentials for basic authorization
+    'H=s@',    # extra headers, form "Header: value string"
+               #
+    'u',       # display method and URL of request
+    'U',       # display request headers also
+    's',       # display status code
+    'S',       # display whole chain of status codes
+    'e',       # display response headers (default for HEAD)
+    'E',       # display whole chain of headers
+    'd',       # don't display content
+               #
+    'h',       # print usage
+    'v',       # print version
+               #
+    'p=s',     # proxy URL
+    'P',       # don't load proxy setting from environment
+               #
+    'o=s',     # output format
 );
 
 Getopt::Long::config("noignorecase", "bundling");
@@ -315,7 +314,7 @@ $method = uc($options{'m'}) if defined $options{'m'};
 
 if ($options{'f'}) {
     if ($options{'c'}) {
-        $allowed_methods{$method} = "C";  # force content
+        $allowed_methods{$method} = "C";    # force content
     }
     else {
         $allowed_methods{$method} = "";
@@ -368,17 +367,20 @@ if (defined $options{'i'}) {
 $content = undef;
 $user_ct = undef;
 if ($allowed_methods{$method} eq "C") {
+
     # This request needs some content
     unless (defined $options{'c'}) {
+
         # set default content type
-        $options{'c'} = ($method eq "POST") ?
-              "application/x-www-form-urlencoded"
+        $options{'c'}
+            = ($method eq "POST")
+            ? "application/x-www-form-urlencoded"
             : "text/plain";
     }
     else {
         die "$progname: Illegal Content-type format\n"
             unless $options{'c'} =~ m,^[\w\-]+/[\w\-.+]+(?:\s*;.*)?$,;
-	$user_ct++;
+        $user_ct++;
     }
     print STDERR "Please enter content ($options{'c'}) to be ${method}ed:\n"
         if -t;
@@ -393,29 +395,30 @@ else {
 # Set up a request.  We will use the same request object for all URLs.
 $request = HTTP::Request->new($method);
 $request->header('If-Modified-Since', $options{'i'}) if defined $options{'i'};
-for my $user_header (@{ $options{'H'} || [] }) {
+for my $user_header (@{$options{'H'} || []}) {
     my ($header_name, $header_value) = split /\s*:\s*/, $user_header, 2;
     $header_name =~ s/^\s+//;
     if (lc($header_name) eq "user-agent") {
-	$header_value .= $ua->agent if $header_value =~ /\s\z/;
-	$ua->agent($header_value);
+        $header_value .= $ua->agent if $header_value =~ /\s\z/;
+        $ua->agent($header_value);
     }
     else {
-	$request->push_header($header_name, $header_value);
+        $request->push_header($header_name, $header_value);
     }
 }
+
 #$request->header('Accept', '*/*');
-if ($options{'c'}) { # will always be set for request that wants content
+if ($options{'c'}) {    # will always be set for request that wants content
     my $header = ($user_ct ? 'header' : 'init_header');
     $request->$header('Content-Type', $options{'c'});
-    $request->header('Content-Length', length $content);  # Not really needed
+    $request->header('Content-Length', length $content);    # Not really needed
     $request->content($content);
 }
 
 $errors = 0;
 
 sub show {
-    my $r = shift;
+    my $r    = shift;
     my $last = shift;
     print $method, " ", $r->request->uri->as_string, "\n" if $options{'u'};
     print $r->request->headers_as_string, "\n" if $options{'U'};
@@ -425,21 +428,24 @@ sub show {
 
 # Ok, now we perform the requests, one URL at a time
 while ($url = shift) {
+
     # Create the URL object, but protect us against bad URLs
     eval {
-	if ($url =~ /^\w+:/ || $options{'b'}) {  # is there any scheme specification
-	    $url = URI->new(decode(locale => $url), decode(locale => $options{'b'}));
-	    $url = $url->abs(decode(locale => $options{'b'})) if $options{'b'};
-	}
-	else {
-	    $url = uf_uri($url);
+        if ($url =~ /^\w+:/ || $options{'b'})
+        {    # is there any scheme specification
+            $url = URI->new(decode(locale => $url),
+                decode(locale => $options{'b'}));
+            $url = $url->abs(decode(locale => $options{'b'})) if $options{'b'};
+        }
+        else {
+            $url = uf_uri($url);
         }
     };
     if ($@) {
-	$@ =~ s/ at .* line \d+.*//;
-	print STDERR $@;
-	$errors++;
-	next;
+        $@ =~ s/ at .* line \d+.*//;
+        print STDERR $@;
+        $errors++;
+        next;
     }
 
     $ua->proxy($url->scheme, decode(locale => $options{'p'})) if $options{'p'};
@@ -450,66 +456,65 @@ while ($url = shift) {
 
     if ($options{'S'}) {
         for my $r ($response->redirects) {
-	    show($r);
+            show($r);
         }
     }
     show($response, $options{'e'});
 
     unless ($options{'d'}) {
-	if ($options{'o'} &&
-	    $response->content_type eq 'text/html') {
-	    eval {
-		require HTML::Parse;
-	    };
-	    if ($@) {
-		if ($@ =~ m,^Can't locate HTML/Parse.pm in \@INC,) {
-		    die "The HTML-Tree distribution need to be installed for the -o option to be used.\n";
-		}
-		else {
-		    die $@;
-		}
-	    }
-	    my $html = HTML::Parse::parse_html($response->content);
-	    {
-		$options{'o'} eq 'ps' && do {
-		    require HTML::FormatPS;
-		    my $f = HTML::FormatPS->new;
-		    print $f->format($html);
-		    last;
-		};
-		$options{'o'} eq 'text' && do {
-		    require HTML::FormatText;
-		    my $f = HTML::FormatText->new;
-		    print $f->format($html);
-		    last;
-		};
-		$options{'o'} eq 'html' && do {
-		    print $html->as_HTML;
-		    last;
-		};
-		$options{'o'} eq 'links' && do {
-		    my $base = $response->base;
-		    $base = $options{'b'} if $options{'b'};
-		    for ( @{ $html->extract_links } ) {
-			my($link, $elem) = @$_;
-			my $tag = uc $elem->tag;
-			$link = URI->new($link)->abs($base)->as_string;
-			print "$tag\t$link\n";
-		    }
-		    last;
-		};
-		$options{'o'} eq 'dump' && do {
-		    $html->dump;
-		    last;
-		};
-		# It is bad to not notice this before now :-(
-		die "Illegal -o option value ($options{'o'})\n";
-	    }
-	}
-	else {
-	    binmode STDOUT unless $options{'a'};
-	    print $response->content;
-	}
+        if ($options{'o'} && $response->content_type eq 'text/html') {
+            eval { require HTML::Parse; };
+            if ($@) {
+                if ($@ =~ m,^Can't locate HTML/Parse.pm in \@INC,) {
+                    die
+                        "The HTML-Tree distribution need to be installed for the -o option to be used.\n";
+                }
+                else {
+                    die $@;
+                }
+            }
+            my $html = HTML::Parse::parse_html($response->content);
+            {
+                $options{'o'} eq 'ps' && do {
+                    require HTML::FormatPS;
+                    my $f = HTML::FormatPS->new;
+                    print $f->format($html);
+                    last;
+                };
+                $options{'o'} eq 'text' && do {
+                    require HTML::FormatText;
+                    my $f = HTML::FormatText->new;
+                    print $f->format($html);
+                    last;
+                };
+                $options{'o'} eq 'html' && do {
+                    print $html->as_HTML;
+                    last;
+                };
+                $options{'o'} eq 'links' && do {
+                    my $base = $response->base;
+                    $base = $options{'b'} if $options{'b'};
+                    for (@{$html->extract_links}) {
+                        my ($link, $elem) = @$_;
+                        my $tag = uc $elem->tag;
+                        $link = URI->new($link)->abs($base)->as_string;
+                        print "$tag\t$link\n";
+                    }
+                    last;
+                };
+                $options{'o'} eq 'dump' && do {
+                    $html->dump;
+                    last;
+                };
+
+                # It is bad to not notice this before now :-(
+                die "Illegal -o option value ($options{'o'})\n";
+            }
+        }
+        else {
+            binmode STDOUT unless $options{'a'};
+            print $response->content;
+        }
     }
 
     $errors++ unless $response->is_success;
@@ -518,8 +523,7 @@ while ($url = shift) {
 exit $errors;
 
 
-sub usage
-{
+sub usage {
     die <<"EOT";
 Usage: $progname [-options] <url>...
     -m <method>   use method for the request (default is '$method')

--- a/bin/lwp-request
+++ b/bin/lwp-request
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 # Simple user agent using LWP library.
 
@@ -180,7 +180,10 @@ Gisle Aas <gisle@aas.no>
 
 =cut
 
-$progname = $0;
+use strict;
+use warnings;
+
+my $progname = $0;
 $progname =~ s,.*[\\/],,;    # use basename only
 $progname =~ s/\.\w*$//;     # strip extension, if any
 
@@ -202,7 +205,7 @@ use HTTP::Date qw(time2str str2time);
 #
 # "" = No content in request, "C" = Needs content in request
 #
-%allowed_methods = (
+my %allowed_methods = (
     GET     => "",
     HEAD    => "",
     POST    => "C",
@@ -219,6 +222,8 @@ use HTTP::Date qw(time2str str2time);
 
     package RequestAgent;
 
+    use strict;
+    use warnings;
     use base qw(LWP::UserAgent);
 
     sub new {
@@ -252,11 +257,11 @@ use HTTP::Date qw(time2str str2time);
     }
 }
 
-$method = uc(lc($progname) eq "lwp-request" ? "GET" : $progname);
+my $method = uc(lc($progname) eq "lwp-request" ? "GET" : $progname);
 
 # Parse command line
 use Getopt::Long;
-
+my %options;
 my @getopt_args = (
     'a',       # content i/o in text(ascii) mode
     'm=s',     # set method
@@ -305,7 +310,7 @@ EOT
 usage() if $options{'h'} || !@ARGV;
 
 # Create the user agent object
-$ua = RequestAgent->new;
+my $ua = RequestAgent->new;
 
 # Load proxy settings from *_proxy environment variables.
 $ua->env_proxy unless $options{'P'};
@@ -344,7 +349,7 @@ $options{'s'} = 1 if $options{'e'};
 if (defined $options{'t'}) {
     $options{'t'} =~ /^(\d+)([smh])?/;
     die "$progname: Illegal timeout value!\n" unless defined $1;
-    $timeout = $1;
+    my $timeout = $1;
     if (defined $2) {
         $timeout *= 60   if $2 eq "m";
         $timeout *= 3600 if $2 eq "h";
@@ -353,6 +358,7 @@ if (defined $options{'t'}) {
 }
 
 if (defined $options{'i'}) {
+    my $time;
     if (-e $options{'i'}) {
         $time = (stat _)[9];
     }
@@ -364,8 +370,8 @@ if (defined $options{'i'}) {
     $options{'i'} = time2str($time);
 }
 
-$content = undef;
-$user_ct = undef;
+my $content;
+my $user_ct;
 if ($allowed_methods{$method} eq "C") {
 
     # This request needs some content
@@ -393,7 +399,7 @@ else {
 }
 
 # Set up a request.  We will use the same request object for all URLs.
-$request = HTTP::Request->new($method);
+my $request = HTTP::Request->new($method);
 $request->header('If-Modified-Since', $options{'i'}) if defined $options{'i'};
 for my $user_header (@{$options{'H'} || []}) {
     my ($header_name, $header_value) = split /\s*:\s*/, $user_header, 2;
@@ -415,7 +421,7 @@ if ($options{'c'}) {    # will always be set for request that wants content
     $request->content($content);
 }
 
-$errors = 0;
+my $errors = 0;
 
 sub show {
     my $r    = shift;
@@ -427,7 +433,7 @@ sub show {
 }
 
 # Ok, now we perform the requests, one URL at a time
-while ($url = shift) {
+while (my $url = shift) {
 
     # Create the URL object, but protect us against bad URLs
     eval {
@@ -452,7 +458,7 @@ while ($url = shift) {
 
     # Send the request and get a response back from the server
     $request->uri($url);
-    $response = $ua->request($request);
+    my $response = $ua->request($request);
 
     if ($options{'S'}) {
         for my $r ($response->redirects) {


### PR DESCRIPTION
This would address issue #184 

* Gets rid of the ```-w``` flag.
* Adds ```use strict;```
* Adds ```use warnigns;```
* Defines all variables where necessary,
* Cleans up code with perltidy.

