### PR TITLE
lc() on possibly undefined value in ->credentials

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Handle undefined values in ->credentials (GH #157)
+
+6.26      2017-04-12
     - Perltidy all apps in the bin/ directory
     - Make all apps in bin/ use strict and warnings (RT #92633)
     - Fix bug tracker URL in metadata

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -83,7 +83,7 @@ my %WriteMakefileArgs = (
     "Test::More" => 0,
     "Test::RequiresInternet" => 0
   },
-  "VERSION" => "6.25",
+  "VERSION" => "6.26",
   "test" => {
     "TESTS" => "t/*.t t/base/*.t t/base/protocols/*.t t/local/*.t t/robot/*.t"
   }

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -660,13 +660,11 @@ sub redirect_ok
     return 1;
 }
 
-
-sub credentials
-{
-    my $self = shift;
-    my $netloc = lc(shift);
-    my $realm = shift || "";
-    my $old = $self->{basic_authentication}{$netloc}{$realm};
+sub credentials {
+    my $self   = shift;
+    my $netloc = lc(shift || '');
+    my $realm  = shift || "";
+    my $old    = $self->{basic_authentication}{$netloc}{$realm};
     if (@_) {
         $self->{basic_authentication}{$netloc}{$realm} = [@_];
     }
@@ -674,7 +672,6 @@ sub credentials
     return @$old if wantarray;
     return join(":", @$old);
 }
-
 
 sub get_basic_credentials
 {

--- a/t/10-attrs.t
+++ b/t/10-attrs.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+
+use LWP::UserAgent;
+plan tests => 9;
+
+# Prevent environment from interfering with test:
+delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
+delete $ENV{HTTPS_CA_FILE};
+delete $ENV{HTTPS_CA_DIR};
+delete $ENV{PERL_LWP_SSL_CA_FILE};
+delete $ENV{PERL_LWP_SSL_CA_PATH};
+delete $ENV{PERL_LWP_ENV_PROXY};
+
+# credentials
+{
+    my $ua = LWP::UserAgent->new();
+    $ua->credentials(undef, 'my realm', 'user', 'pass');
+    is($ua->credentials(undef, 'my realm'), 'user:pass', 'credentials: undef netloc');
+
+    $ua->credentials('example.com:80', undef, 'user', 'pass');
+    is($ua->credentials('example.com:80', undef), 'user:pass', 'credentials: undef realm');
+
+    $ua->credentials('example.com:80', 'my realm', undef, 'pass');
+    is($ua->credentials('example.com:80', 'my realm'), ':pass', 'credentials: undef username');
+
+    $ua->credentials('example.com:80', 'my realm', 'user', undef);
+    is($ua->credentials('example.com:80', 'my realm'), 'user:', 'credentials: undef pass');
+
+    $ua->credentials(undef, undef, 'user', 'pass');
+    is($ua->credentials(undef, undef), 'user:pass', 'credentials: undef netloc and realm');
+
+    $ua->credentials(undef, undef, undef, undef);
+    is($ua->credentials(undef, undef), ':', 'credentials: undef all');
+
+    $ua->credentials('example.com:80', 'my realm', 'user', 'pass');
+    is($ua->credentials('example.com:80', 'my realm'), 'user:pass', 'credentials: got proper creds for example:80');
+
+    # ask for the credentials incorrectly
+    my $creds = $ua->credentials('example.com');
+    is($creds, undef, 'credentials: no realm on request for info');
+
+    # ask for the credentials incorrectly with bad realm
+    $creds = $ua->credentials('example.com', 'invalid');
+    is($creds, undef, 'credentials: invalid realm on request for info');
+}


### PR DESCRIPTION
This PR should help with: https://github.com/libwww-perl/libwww-perl/issues/157

In ```->credentials``` in ```LWP::UserAgent``` we do ```my $netloc = lc(shift);```. This value could be undefined and when it's so, it causes warnings.

This is a proposal for a fix for that, ```my $netloc = lc(shift || '');``` but I can see going with other options as well.  Please review this and supply your thoughts.

Also, I started another test file ```t/10-attrs.t``` to allow us to start exercising every attribute to hopefully get the coverage up a bit and to help us when fixing documentation later.

-- Chase