### PR TITLE
Test LWP has a Version sub/method

### DIFF
--- a/t/base/version.t
+++ b/t/base/version.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use LWP;
+use Test::More;
+
+plan tests => 1;
+
+is(LWP::Version(), $LWP::VERSION, 'LWP::Version() returns the same as $LWP::VERSION');


### PR DESCRIPTION
A simple test to make sure LWP->Version or LWP::Version() returns
the same as $LWP::VERSION.