### PR TITLE
Calculate digest of body only if auth-int specified.

### DIFF
--- a/lib/LWP/Authen/Digest.pm
+++ b/lib/LWP/Authen/Digest.pm
@@ -26,7 +26,7 @@ sub auth_header {
     push(@digest, $auth_param->{nonce});
 
     if ($auth_param->{qop}) {
-	push(@digest, $nc, $cnonce, ($auth_param->{qop} =~ m|^auth[,;]auth-int$|) ? 'auth' : $auth_param->{qop});
+	push(@digest, $nc, $cnonce, ($auth_param->{qop} =~ m|^auth[,;]\s*auth-int$|) ? 'auth' : $auth_param->{qop});
     }
 
     $md5->add(join(":", $request->method, $uri));
@@ -40,12 +40,13 @@ sub auth_header {
     my %resp = map { $_ => $auth_param->{$_} } qw(realm nonce opaque);
     @resp{qw(username uri response algorithm)} = ($user, $uri, $digest, "MD5");
 
-    if (($auth_param->{qop} || "") =~ m|^auth([,;]auth-int)?$|) {
+    my $auth_qop = $auth_param->{qop} || "";
+    if ($auth_qop =~ m|^auth([,;]\s*auth-int)?$|) {
 	@resp{qw(qop cnonce nc)} = ("auth", $cnonce, $nc);
     }
 
     my(@order) = qw(username realm qop algorithm uri nonce nc cnonce response);
-    if($request->method =~ /^(?:POST|PUT)$/) {
+    if($auth_qop eq 'auth-int' && $request->method =~ /^(?:POST|PUT)$/) {
 	$md5->add($request->content);
 	my $content = $md5->hexdigest;
 	$md5->reset;


### PR DESCRIPTION
This applies the roughly the patch from issue #130 and adds tests to
check the changes work correctly.

This isn't quite complete yet.  I still want to do the following,

* Test against a live web server manually to verify the original issue and that servers definitely work with this behaviour.
* Consider adding a mechanism to allow for the legacy mode of operation in case there are also legitimate servers in the wild that do work in the way LWP was operating.