### PR TITLE
Allow multiple realms on auth

### DIFF
--- a/lib/LWP/Authen/Basic.pm
+++ b/lib/LWP/Authen/Basic.pm
@@ -48,7 +48,7 @@ sub authenticate
     }
 
     # check that the password has changed
-    my ($olduser, $oldpass) = $ua->credentials($host_port, $realm);
+    my ($olduser, $oldpass);# = $ua->credentials($host_port, $realm);
     return $response if (defined $olduser and defined $oldpass and
                          $user eq $olduser and $pass eq $oldpass);
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -417,8 +417,9 @@ sub request {
                         "Unsupported authentication scheme '$scheme'");
                 next CHALLENGE;
             }
-            return $class->authenticate($self, $proxy, $challenge, $response,
+            $response = $class->authenticate($self, $proxy, $challenge, $response,
                 $request, $arg, $size);
+            return $response if $response->is_success;
         }
         return $response;
     }


### PR DESCRIPTION
This is the start of a fix for issue #248.  It's not quite perfect, I've kept the commits separate for now so it's easy to see what's going on.

In principle allowing multiple providers *should* be easy, but there's another feature in the library designed to prevent extra auth attempts that was blocking it from working.  My last commit simply clobbers that feature for now to prove that in principle this can work, but I do want to improve that.

Once this is done it will probably fix issue #201 too.