### PR TITLE
revert vars pragma usage removal to not look for external dependencies

### DIFF
--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -512,6 +512,6 @@ sub increment_response_count {
 #-----------------------------------------------------------
 package LWP::Protocol::http::Socket;
 
-use base qw(LWP::Protocol::http::SocketMethods Net::HTTP);
+use parent -norequire, qw(LWP::Protocol::http::SocketMethods Net::HTTP);
 
 1;


### PR DESCRIPTION
Removing vars pragma usage in PR #114 and replacing it with `use base` had unwanted side-effects.

`@ISA` did not look for external dependencies whereas`use base` does.

If the user is in a directory in which he does not have read access and the package does not exist externally, this is an "other error" and Perl aborts:
```stat("./LWP/Protocol/http/SocketMethods.pm", 0x7fff176b5990) = -1 EACCES (Permission denied)```