### PR TITLE
Use tr/// instead of s/// where appropriate

### DIFF
--- a/lib/LWP/Protocol.pm
+++ b/lib/LWP/Protocol.pm
@@ -53,7 +53,7 @@ sub implementor
 
     return '' unless $scheme =~ /^([.+\-\w]+)$/;  # check valid URL schemes
     $scheme = $1; # untaint
-    $scheme =~ s/[.+\-]/_/g;  # make it a legal module name
+    $scheme =~ tr/.+-/_/;  # make it a legal module name
 
     # scheme not yet known, look for a 'use'd implementation
     $ic = "LWP::Protocol::$scheme";  # default location

--- a/lib/LWP/Protocol/gopher.pm
+++ b/lib/LWP/Protocol/gopher.pm
@@ -185,7 +185,7 @@ sub gopher2url
 sub menu2html {
     my($menu) = @_;
 
-    $menu =~ s/\015//g;  # remove carriage return
+    $menu =~ tr/\015//d;  # remove carriage return
     my $tmp = <<"EOT";
 <HTML>
 <HEAD>

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -232,7 +232,7 @@ sub request
     $request_headers->scan(sub {
 			       my($k, $v) = @_;
 			       $k =~ s/^://;
-			       $v =~ s/\n/ /g;
+			       $v =~ tr/\n/ /;
 			       push(@h, $k, $v);
 			   });
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -387,7 +387,7 @@ sub request {
             }
             $scheme = $1;                  # untainted now
             my $class = "LWP::Authen::\u$scheme";
-            $class =~ s/-/_/g;
+            $class =~ tr/-/_/;
 
             no strict 'refs';
             unless (%{"$class\::"}) {


### PR DESCRIPTION
Not that it would really matter in these particular cases, but `tr` is much faster than `s` in trivial cases like these. And may result in (subjectively) cleaner code.