### PR TITLE
Include unmatched connect error in status string.

### DIFF
--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -42,6 +42,8 @@ sub _new_socket
 	    $@ =~ /\b(Crypt-SSLeay can't verify hostnames)\b/
 	) {
 	    $status .= " ($1)";
+	} elsif ($@) {
+	    $status .= " ($@)";
 	}
 	die "$status\n\n$@";
     }


### PR DESCRIPTION
Prior to this change a HTTPS connection would not get additional error
information added to the status string. Compare the $@ contents for the
"Connection refused" case with IO::Socket::INET which was displayed:
```
IO::Socket::INET: connect: Connection refused
```
... and IO::Socket::SSL where the information was lost:
```
Connection refused
```