### PR TITLE
Don't use insecure `open FILEHANDLE,EXPR`

### DIFF
--- a/lib/LWP/Protocol/file.pm
+++ b/lib/LWP/Protocol/file.pm
@@ -126,17 +126,17 @@ sub request
 
     # read the file
     if ($method ne "HEAD") {
-	open(F, $path) or return new
+	open(my $fh, '<', $path) or return new
 	    HTTP::Response(HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 			   "Cannot read file '$path': $!");
-	binmode(F);
+	binmode($fh);
 	$response =  $self->collect($arg, $response, sub {
 	    my $content = "";
-	    my $bytes = sysread(F, $content, $size);
+	    my $bytes = sysread($fh, $content, $size);
 	    return \$content if $bytes > 0;
 	    return \ "";
 	});
-	close(F);
+	close($fh);
     }
 
     $response;


### PR DESCRIPTION
`LWP::Protocol::file` can open existent file from `file://` scheme. However, current version of LWP uses `open FILEHANDLE,EXPR` and it has ability to execute arbitrary command as below:

```
$ touch '|echo vulnerable'
$ GET 'file:|echo vulnerable'
Use of uninitialized value $bytes in numeric gt (>) at /usr/share/perl5/LWP/Protocol/file.pm line 137.
vulnerable
```