### PR TITLE
fix run_handlers to allow assigning to the request / response

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -897,16 +897,20 @@ sub handlers {
 
 sub run_handlers {
     my($self, $phase, $o) = @_;
+
+    # were we pass $_[2] to the callbacks, instead of $o, so that they
+    # can assign to it; e.g. request_prepare is documented to allow
+    # that
     if (defined(wantarray)) {
         for my $h ($self->handlers($phase, $o)) {
-            my $ret = $h->{callback}->($o, $self, $h);
+            my $ret = $h->{callback}->($_[2], $self, $h);
             return $ret if $ret;
         }
         return undef;
     }
 
     for my $h ($self->handlers($phase, $o)) {
-        $h->{callback}->($o, $self, $h);
+        $h->{callback}->($_[2], $self, $h);
     }
 }
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -898,7 +898,7 @@ sub handlers {
 sub run_handlers {
     my($self, $phase, $o) = @_;
 
-    # were we pass $_[2] to the callbacks, instead of $o, so that they
+    # here we pass $_[2] to the callbacks, instead of $o, so that they
     # can assign to it; e.g. request_prepare is documented to allow
     # that
     if (defined(wantarray)) {

--- a/t/base/ua_handlers.t
+++ b/t/base/ua_handlers.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+use LWP::UserAgent ();
+use HTTP::Request ();
+use HTTP::Response ();
+
+# Prevent environment from interfering with test:
+delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
+delete $ENV{HTTPS_CA_FILE};
+delete $ENV{HTTPS_CA_DIR};
+delete $ENV{PERL_LWP_SSL_CA_FILE};
+delete $ENV{PERL_LWP_SSL_CA_PATH};
+delete $ENV{PERL_LWP_ENV_PROXY};
+
+my $ua = LWP::UserAgent->new;
+$ua->add_handler(
+    request_send => sub {
+        my ($request, $ua, $h) = @_;
+        return HTTP::Response->new(200,'OK',[],'ok');
+    }
+);
+
+subtest 'request_send' => sub {
+    my $res = $ua->get('http://www.example.com');
+    ok($res->is_success, 'handler should succeed');
+    is($res->content,'ok','handler-provided response should be used');
+};
+
+subtest 'request_prepare' => sub {
+    $ua->add_handler(
+        request_prepare => sub {
+            # the docs say this is the way to replace the request
+            $_[0] = HTTP::Request->new(POST=>'http://mmm.example.com/');
+        }
+    );
+    my $res = $ua->get('http://www.example.com');
+    my $effective_request = $res->request;
+    is($effective_request->method,'POST',
+       'the request should have been modified by the handler');
+    is($effective_request->uri,'http://mmm.example.com/',
+       'the request should have been modified by the handler');
+};
+
+done_testing;


### PR DESCRIPTION
The documentation of the `request_prepare` handler says:

    The method can assign a new request object to $_[0] to replace the
    request that is sent fully.

but that didn't work before this commit.