### PR TITLE
Nawglan/fix cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -46,7 +46,10 @@ on 'test' => sub {
     requires 'FindBin';
     requires 'Test::CPAN::Meta';
     requires 'Test::Pod::Spelling::CommonMistakes' => '1.000';
+    requires 'Test::CheckManifest' => '1.29';
+    requires 'Test::Kwalitee'      => '1.22';
     requires 'Authen::NTLM' => '1.02';
+    requires 'Test::CPAN::Changes' => '0.4';
 };
 
 on 'develop' => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -44,6 +44,9 @@ on 'test' => sub {
     requires 'Test::More';
     requires 'Test::RequiresInternet';
     requires 'FindBin';
+    requires 'Test::CPAN::Meta';
+    requires 'Test::Pod::Spelling::CommonMistakes' => '1.000';
+    requires 'Authen::NTLM' => '1.02';
 };
 
 on 'develop' => sub {
@@ -53,4 +56,5 @@ on 'develop' => sub {
     requires 'Test::Kwalitee'      => '1.22';
     requires 'Test::Pod::Spelling::CommonMistakes' => '1.000';
     requires 'Try::Tiny'  => '0.24';
+    requires 'Authen::NTLM' => '1.02';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -44,12 +44,6 @@ on 'test' => sub {
     requires 'Test::More';
     requires 'Test::RequiresInternet';
     requires 'FindBin';
-    requires 'Test::CPAN::Meta';
-    requires 'Test::Pod::Spelling::CommonMistakes' => '1.000';
-    requires 'Test::CheckManifest' => '1.29';
-    requires 'Test::Kwalitee'      => '1.22';
-    requires 'Authen::NTLM' => '1.02';
-    requires 'Test::CPAN::Changes' => '0.4';
 };
 
 on 'develop' => sub {


### PR DESCRIPTION
cpan-prc challenge 2018.

When trying to use dzil to run tests, it was complaining about missing dependencies.  Looked at the cpanfile and moved some modules from the develop section to the test section, and added a missing dependency to the develop section.