### PR TITLE
use hash access for send_te

### DIFF
--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -30,7 +30,7 @@ sub _new_socket
 					Proto    => 'tcp',
 					Timeout  => $timeout,
 					KeepAlive => !!$self->{ua}{conn_cache},
-					SendTE    => $self->{ua}->send_te,
+					SendTE    => $self->{ua}{send_te},
 					$self->_extra_sock_opts($host, $port),
 				       );
 


### PR DESCRIPTION
This matches with the other hash accessors in this block and should
prevent errors from downstream code that relies on `$self->{ua}` not
being blessed yet.

Fixes #280 

I should mention I have done no digging whatsoever into why this error is happening, but the code was inconsistent: It looks like LWP has always used hash accessors in this constructor, and never assumed that it was a blessed object passed-in.