### PR TITLE
Do not forward the Authentication header after 3xx

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -321,7 +321,7 @@ sub request {
         my $referral = $request->clone;
 
         # These headers should never be forwarded
-        $referral->remove_header('Host', 'Cookie');
+        $referral->remove_header('Host', 'Cookie', 'Authentication');
 
         if (   $referral->header('Referer')
             && $request->uri->scheme eq 'https'


### PR DESCRIPTION
The `Authorization` header is sent when retrying a query after a `401`
response. Usually, a cookie is set, which holds the "authorized" status
of the agent.

If the query including the `Authentication` header is accepted
(i.e. authentication is valid), and the server sends a `3xx` response
back, the original query is cloned, and some headers are removed.

The `Authentication` header must also be removed, otherwise the query
might fail again (with a `403`), for example when the `Location` in
the `3xx` response is a redirect to a different domain, in a different
authorization realm.

Actual debugging and fix by Sergey Belikov.

This should fix #131.