### PR TITLE
Don't install HTTP::Status with version 6.17

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -22,7 +22,7 @@ on 'runtime' => sub {
     requires 'HTTP::Request' => '6';
     requires 'HTTP::Request::Common' => '6';
     requires 'HTTP::Response' => '6';
-    requires 'HTTP::Status' => '6';
+    requires 'HTTP::Status' => '6.18';
     requires 'IO::Select';
     requires 'IO::Socket';
     requires 'LWP::MediaTypes' => '6';
@@ -44,6 +44,7 @@ on 'test' => sub {
     requires 'Test::More';
     requires 'Test::RequiresInternet';
     requires 'FindBin';
+    requires 'HTTP::Status' => '6.18';
 };
 
 on 'develop' => sub {


### PR DESCRIPTION
HTTP::Status 6.16 and 6.17 break the installation of LWP::UserAgent
due to always sending an 'OK' status message even when 404's are being
thrown. This breaks t/local/http.t