### PR TITLE
Allow IPv6 proxy hosts starting with [.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,38 @@ addons:
       - aspell-en
 language: perl
 perl:
-  - blead
   - dev
-  - '5.28'
-  - '5.26'
-  - '5.24'
-  - '5.22'
-  - '5.20'
-  - '5.18'
-  - '5.16'
-  - '5.14'
-  - '5.12'
-  - '5.10'
-  - '5.8'
+  - "blead"
+  - "blead-thr"
+  - "5.28"
+  - "5.28-thr"
+  - "5.26"
+  - "5.26-thr"
+  - "5.24"
+  - "5.24-thr"
+  - "5.22"
+  - "5.22-thr"
+  - "5.20"
+  - "5.20-thr"
+  - "5.18"
+  - "5.18-thr"
+  - "5.16"
+  - "5.16-thr"
+  - "5.14"
+  - "5.14-thr"
+  - "5.12"
+  - "5.12-thr"
+  - "5.10"
+  - "5.10-thr"
+  - "5.8"
+  - "5.8-thr"
 cache:
   directories:
     - $HOME/perl5
 matrix:
   allow_failures:
     - perl: blead
+    - perl: blead-thr
   fast_finish: 1
   include:
     - env: COVERAGE=1
@@ -44,6 +57,7 @@ before_install:
   - build-dist
   - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
 install:
+  - cpan-install Data::Dump Authen::NTLM Test::Spelling Test::Pod Test::Pod::Coverage Test::Version Test::EOL
   - cpan-install --deps       # installs prereqs, including optional modules
   - cpan-install --coverage   # installs converage prereqs, if enabled
 before_script:

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Change history for libwww-perl
 
 {{$NEXT}}
     - Improve ->add_handler documentation (GH #272) (Julien Fiegehenn)
+    - Alter our rule set to allow IPv6 proxy hosts beginning with [. (GH #237)
 
 6.36      2018-10-10 02:20:58Z
     - fix broken link https://metacpan.org/pod/LWP::Simple by fixing pod

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1059,7 +1059,7 @@ sub proxy {
         my $url = shift;
         if (defined($url) && length($url)) {
             Carp::croak("Proxy must be specified as absolute URI; '$url' is not") unless $url =~ /^$URI::scheme_re:/;
-            Carp::croak("Bad http proxy specification '$url'") if $url =~ /^https?:/ && $url !~ m,^https?://\w,;
+            Carp::croak("Bad http proxy specification '$url'") if $url =~ /^https?:/ && $url !~ m,^https?://[\w[],;
         }
         $self->{proxy}{$key} = $url;
         $self->set_my_handler("request_preprepare", \&_need_proxy)

--- a/xt/author/live/jigsaw/redirect-post.t
+++ b/xt/author/live/jigsaw/redirect-post.t
@@ -41,4 +41,3 @@ unlike($content, qr/GET not implemented/, 'response was not a GET');
 like($uri, qr/303_ok\.html/, 'redirected to the correct page');
 unlike($content, qr/POST not allowed on this resource/, '303 OK endpoint was not a POST');
 like($content, qr/Your browser made it!/, 'response shows that we followed a 307 POST redirect and then a 303 GET redirect');
-


### PR DESCRIPTION
Altered the regular expression that checked for a sane-ish looking
URL for our proxy host:

 if $url =~ /^https?:/ && $url !~ m,^https?://\w,;

Given this expression, a proxy host in the form of
http://[::1]:33485/ would fail because it starts with a left bracket.

The expression above has been altered to:

 if $url =~ /^https?:/ && $url !~ m,^https?://[\w[],;

Which will allow it to begin with a word character or a left bracket.

This will resolve issue #237