### PR TITLE
SKIP nntp test for now

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Change history for libwww-perl
 {{$NEXT}}
     - Document current best practices (Olaf Alders)
     - Document handlers in their order of operation (Olaf Alders)
+    - SKIP t/base/protocols/nntp.t for now
 
 6.38      2019-03-25 18:58:58Z
     - Update Net::HTTP dependency from 6.07 to 6.18 (GH#310) (Olaf Alders)

--- a/t/base/protocols/nntp.t
+++ b/t/base/protocols/nntp.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use LWP::UserAgent ();
-use Test::More;
+use Test::More skip_all => 'nntp.perl.org is unstable and Test::RequiresInternet is not catching it';
 use Test::RequiresInternet ( 'nntp.perl.org' => 119 );
 
 plan tests => 1;


### PR DESCRIPTION
Test::RequiresInternet doesn't seem to handle the case of nntp.perl.org
going down.  This breaks everyone's tests.

Fixes #307 