### PR TITLE
Add the patch method to LWP::UserAgent.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Add the patch method (GH#116)
 
 6.39      2019-05-06 14:18:39Z
     - Document current best practices (GH#314) (Olaf Alders)

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -490,6 +490,22 @@ sub head {
 }
 
 
+sub patch {
+    require HTTP::Request::Common;
+    my($self, @parameters) = @_;
+    my @suff = $self->_process_colonic_headers(\@parameters, (ref($parameters[1]) ? 2 : 1));
+
+    # this work-around is in place as HTTP::Request::Common
+    # did not implement a patch convenience method until
+    # version 6.12. Once we can bump the prereq to at least
+    # that version, we can use ::PATCH instead of this hack
+    my $req = HTTP::Request::Common::PUT(@parameters);
+    $req->method('PATCH');
+
+    $self->_maybe_copy_default_content_type($req, @parameters);
+    return $self->request($req, @suff);
+}
+
 sub put {
     require HTTP::Request::Common;
     my($self, @parameters) = @_;
@@ -1871,6 +1887,34 @@ will be downloaded again.  The modification time of the file will be
 forced to match that of the server.
 
 The return value is an L<HTTP::Response> object.
+
+=head2 patch
+
+    # Any version of HTTP::Message works with this form:
+    my $res = $ua->patch( $url, $field_name => $value, Content => $content );
+
+    # Using hash or array references requires HTTP::Message >= 6.12
+    use HTTP::Request 6.12;
+    my $res = $ua->patch( $url, \%form );
+    my $res = $ua->patch( $url, \@form );
+    my $res = $ua->patch( $url, \%form, $field_name => $value, ... );
+    my $res = $ua->patch( $url, $field_name => $value, Content => \%form );
+    my $res = $ua->patch( $url, $field_name => $value, Content => \@form );
+
+This method will dispatch a C<PATCH> request on the given URL, with
+C<%form> or C<@form> providing the key/value pairs for the fill-in form
+content. Additional headers and content options are the same as for
+the L<LWP::UserAgent/get> method.
+
+CAVEAT:
+
+This method can only accept content that is in key-value pairs when using
+L<HTTP::Request::Common> prior to version C<6.12>. Any use of hash or array
+references will result in an error prior to version C<6.12>.
+
+This method will use the C<PATCH> function from L<HTTP::Request::Common>
+to build the request.  See L<HTTP::Request::Common> for a details on
+how to pass form content and other advanced features.
 
 =head2 post
 

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -4,7 +4,7 @@ use HTTP::Request ();
 use LWP::UserAgent ();
 use Test::More;
 
-plan tests => 41;
+plan tests => 42;
 
 # Prevent environment from interfering with test:
 delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
@@ -94,6 +94,18 @@ EOT
 
 ok($ua->put("http://www.example.com", [x => "y", f => "ff"])->content, <<EOT);
 PUT http://www.example.com
+User-Agent: foo/0.1
+Content-Length: 8
+Content-Type: application/x-www-form-urlencoded
+Foo: bar
+Multi: 1
+Multi: 2
+
+x=y&f=ff
+EOT
+
+ok($ua->patch("http://www.example.com", [x => "y", f => "ff"])->content, <<EOT);
+PATCH http://www.example.com
 User-Agent: foo/0.1
 Content-Length: 8
 Content-Type: application/x-www-form-urlencoded


### PR DESCRIPTION
Much like the previously added `put` function, the `patch` function will
require a specific version of HTTP::Request::Common. This time, though,
we will need at least version 6.12.

This is largely a copy-paste of the already added `put` function. All of
the current tests we have in place that test the `put` funtion were
duplicated for the new `patch` function. The same logic gate that only
tests when we have the proper version of HTTP::Request::Common was added
for the 6.12 check.

This makes LWP::UserAgent a bit simpler to work with RESTful endpoints
in that we now directly support the most common HTTP verbs: `HEAD`,
`GET`, `DELETE`, `PUT`, `POST`, `PATCH`.

Fixes #116