### PR TITLE
Make file arg for mirror mandatory #304

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -966,6 +966,8 @@ sub mirror
 {
     my($self, $url, $file) = @_;
 
+    die "Local file name is missing" unless $file;
+    
     my $request = HTTP::Request->new('GET', $url);
 
     # If the file exists, add a cache-related header
@@ -979,10 +981,10 @@ sub mirror
 
     my $response = $self->request($request, $tmpfile);
     if ( $response->header('X-Died') ) {
-	die $response->header('X-Died');
+        die $response->header('X-Died');
     }
 
-    # Only fetching a fresh copy of the would be considered success.
+    # Only fetching a fresh copy of the file would be considered success.
     # If the file was not modified, "304" would returned, which
     # is considered by HTTP::Status to be a "redirect", /not/ "success"
     if ( $response->is_success ) {
@@ -1017,7 +1019,7 @@ sub mirror
     }
     # The local copy is fresh enough, so just delete the temp file
     else {
-	unlink($tmpfile);
+        unlink($tmpfile);
     }
     return $response;
 }

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Fatal;
 
 use Config;
 use FindBin qw($Bin);
@@ -62,7 +63,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 90;
+    plan tests => 94;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -287,6 +288,16 @@ sub _test {
         isa_ok($res, 'HTTP::Response', 'post: good response object');
         ok($res->is_success, 'post: is_success');
         ok($res->content =~ /^Content-Type: multipart\/form-data; boundary=/m, 'post: multipart good');
+    }
+    { # mirror
+        ok(exception { $ua->mirror(url("/echo/foo", $base)) }, 'mirror: filename required');
+        my $copy = "lwp-base-test-$$"; # downloaded copy
+        my $res = $ua->mirror(url("/echo/foo", $base), $copy);
+        isa_ok($res, 'HTTP::Response', 'mirror: good response object');
+        ok($res->is_success, 'mirror: is_success');
+        
+        ok(-s $copy, 'mirror: file exists and is not empty');
+        unlink($copy);
     }
     { # partial
         my $req = HTTP::Request->new(  GET => url("/partial", $base) );


### PR DESCRIPTION
The ticket talks about "basic parameter validation". I think we only need to make sure the second arg is there. No need to check the URL as that will be done when we GET the file.

Closes #304 