### PR TITLE
Allow mirroring to files called '0'

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -966,7 +966,7 @@ sub mirror
 {
     my($self, $url, $file) = @_;
 
-    die "Local file name is missing" unless $file;
+    die "Local file name is missing" unless defined $file && length $file;
 
     my $request = HTTP::Request->new('GET', $url);
 

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -63,7 +63,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 94;
+    plan tests => 96;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -291,6 +291,7 @@ sub _test {
     }
     { # mirror
         ok(exception { $ua->mirror(url("/echo/foo", $base)) }, 'mirror: filename required');
+        ok(exception { $ua->mirror(url("/echo/foo", $base), q{}) }, 'mirror: non empty filename required');
         my $copy = "lwp-base-test-$$"; # downloaded copy
         my $res = $ua->mirror(url("/echo/foo", $base), $copy);
         isa_ok($res, 'HTTP::Response', 'mirror: good response object');
@@ -298,6 +299,10 @@ sub _test {
 
         ok(-s $copy, 'mirror: file exists and is not empty');
         unlink($copy);
+
+        $ua->mirror(url("/echo/foo", $base),q{0});
+        ok(1, 'can write to a file called 0');
+        unlink('0');
     }
     { # partial
         my $req = HTTP::Request->new(  GET => url("/partial", $base) );


### PR DESCRIPTION
After GH#326 we were no longer able to mirror to files called '0'

Now we check for length and definedness rather than truthfullness

And I added tests