### PR TITLE
Set up unlimited conn cache on keep_alive => undef

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -72,10 +72,11 @@ sub new
 
     my $cookie_jar = delete $cnf{cookie_jar};
     my $conn_cache = delete $cnf{conn_cache};
+    my $keep_alive_exists = exists $cnf{keep_alive};
     my $keep_alive = delete $cnf{keep_alive};
 
     Carp::croak("Can't mix conn_cache and keep_alive")
-	  if $conn_cache && $keep_alive;
+	  if $conn_cache && $keep_alive_exists;
 
     my $protocols_allowed   = delete $cnf{protocols_allowed};
     my $protocols_forbidden = delete $cnf{protocols_forbidden};
@@ -130,7 +131,7 @@ sub new
     $self->protocols_allowed(  $protocols_allowed  ) if $protocols_allowed;
     $self->protocols_forbidden($protocols_forbidden) if $protocols_forbidden;
 
-    if ($keep_alive) {
+    if ($keep_alive_exists) {
 	$conn_cache ||= { total_capacity => $keep_alive };
     }
     $self->conn_cache($conn_cache) if $conn_cache;

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -4,7 +4,7 @@ use HTTP::Request ();
 use LWP::UserAgent ();
 use Test::More;
 
-plan tests => 41;
+plan tests => 43;
 
 # Prevent environment from interfering with test:
 delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
@@ -164,3 +164,8 @@ $ua = LWP::UserAgent->new();
 is($ua->proxy('http'), "http://example.com", "\$ua->proxy('http')");
 $ua = LWP::UserAgent->new(env_proxy => 0);
 is($ua->proxy('http'),                undef, "\$ua->proxy('http')");
+
+$ua = LWP::UserAgent->new();
+is($ua->conn_cache, undef, "\$ua->conn_cache");
+$ua = LWP::UserAgent->new(keep_alive => undef);
+is($ua->conn_cache->total_capacity, undef, "\$ua->conn_cache->total_capacity");


### PR DESCRIPTION
Matches implementation with the docs, which say the cache is created
based on whether keep_alive is passed in, not whether it's defined.