### PR TITLE
Add the patch method to LWP::UserAgent.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Change history for libwww-perl
 {{$NEXT}}
     - Add retry handling for a stale nonce with digest authentication (marmotil
       and Frank Maas) (GH#40, GH#313, GH#321)
+    - Add the patch method (GH#116)
 
 6.41      2019-10-28 14:42:06Z
     - Allow mirroring to files called '0' (GH#329) (Mark Fowler)

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -4,7 +4,7 @@ use HTTP::Request ();
 use LWP::UserAgent ();
 use Test::More;
 
-plan tests => 45;
+plan tests => 46;
 
 # Prevent environment from interfering with test:
 delete $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME};
@@ -101,6 +101,17 @@ Foo: bar
 Multi: 1
 Multi: 2
 
+x=y&f=ff
+EOT
+
+ok($ua->patch("http://www.example.com", [x => "y", f => "ff"])->content, <<EOT);
+PATCH http://www.example.com
+User-Agent: foo/0.1
+Content-Length: 8
+Content-Type: application/x-www-form-urlencoded
+Foo: bar
+Multi: 1
+Multi: 2
 x=y&f=ff
 EOT
 

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -63,7 +63,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 103;
+    plan tests => 106;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -126,6 +126,17 @@ sub _test {
         );
         isa_ok($res, 'HTTP::Response', 'simple echo 2: good response object');
         is($res->code, 200, 'simple echo 2: code 200');
+    }
+    { # patch
+        my $res = $ua->patch(url("/echo/path_info?query", $base),
+            Accept => 'text/html',
+            Accept => 'text/plain; q=0.9',
+            Accept => 'image/*',
+            X_Foo => "Bar",
+        );
+        isa_ok($res, 'HTTP::Response', 'patch: good response object');
+        is($res->code, 200, 'put: code 200');
+        like($res->content, qr/^From: gisle\@aas.no$/m, 'patch: good From');
     }
     { # put
         my $res = $ua->put(url("/echo/path_info?query", $base),
@@ -520,6 +531,13 @@ sub daemonize {
         $c->send_file("tmp$$");
 
         unlink("tmp$$");
+    };
+    $router{patch_echo} = sub {
+        my($c, $req) = @_;
+        $c->send_basic_header(200);
+        $c->print("Content-Type: message/http\015\012");
+        $c->send_crlf;
+        $c->print($req->as_string);
     };
     $router{put_echo} = sub {
         my($c, $req) = @_;


### PR DESCRIPTION
Much like the previously added `put` method, the `patch` method will
require a specific version of HTTP::Request::Common. This time, though,
we will need at least version 6.12.

This is largely a copy-paste of the already added `put` method. All of
the current tests we have in place that test the `put` method were
duplicated for the new `patch` method. The same logic gate that only
tests when we have the proper version of HTTP::Request::Common was added
for the 6.12 check.

This makes LWP::UserAgent a bit simpler to work with RESTful endpoints
in that we now directly support the most common HTTP verbs: `HEAD`,
`GET`, `DELETE`, `PUT`, `POST`, `PATCH`.

Fixes #116