### PR TITLE
Add blank line after POD heading for patch method

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1893,6 +1893,7 @@ forced to match that of the server.
 The return value is an L<HTTP::Response> object.
 
 =head2 patch
+
     # Any version of HTTP::Message works with this form:
     my $res = $ua->patch( $url, $field_name => $value, Content => $content );
 


### PR DESCRIPTION
Omitting this blank line makes certain POD parsers believe that the
following line is still a part of the heading. This can be seen on
metacpan.org, for instance:

![image](https://user-images.githubusercontent.com/21243/73645223-2c822280-4677-11ea-8979-33ea9e3390a1.png)
