### PR TITLE
Fix a looping regression for 303 responses without a Location header

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Fix a looping regression in 6.45 for redirect responses without
+      a Location header (GH PR#342, Niko Tyni)
 
 6.45      2020-06-08 14:51:28Z
     - Fix Client-Warning: Internal response sometimes reset (GH#341) (Jonathan

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -300,10 +300,12 @@ sub request {
     my $response = $self->simple_request($request, $arg, $size);
     $response->previous($previous) if $previous;
 
-    if ($response->header('Location') && $response->redirects >= $self->{max_redirect}) {
-        $response->header("Client-Warning" =>
+    if ($response->redirects >= $self->{max_redirect}) {
+        if ($response->header('Location')) {
+            $response->header("Client-Warning" =>
                 "Redirect loop detected (max_redirect = $self->{max_redirect})"
-        );
+            );
+        }
         return $response;
     }
 


### PR DESCRIPTION
The change in 6.45 had a side effect of making it look at max_redirect only when the Location header is set.

The libapache2-mod-perl2 test suite implements a test server that answers with HTTP code 303 without including such a header.

RFC 7231 is not very clear on whether Location is required, although
the response doesn't make much sense without it.

Some googling reveals this is not a new question.

  https://stackoverflow.com/questions/16194988/for-which-3xx-http-codes-is-the-location-header-mandatory

For the sake of robustness I suppose libwww-perl needs to be fixed.

Bug-Debian: https://bugs.debian.org/962904