### PR TITLE
Fix RT #81381 - Make LWP::UserAgent robust to 5.17.6/5.18 hash randomization

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    Fix RT #81381 - Make LWP::UserAgent robust to 5.17.6/5.18 hash
+    randomization (GH#355) (Yves Orton and Olaf Alders)
 
 6.49      2020-09-24 00:27:56Z
     - Require network testing enabled for t/redirect.t (GH#351) (Olaf Alders)

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -734,7 +734,8 @@ sub ssl_opts {
 	return $old;
     }
 
-    return keys %{$self->{ssl_opts}};
+    my @opts= sort keys %{$self->{ssl_opts}};
+    return @opts;
 }
 
 sub parse_head {
@@ -886,9 +887,8 @@ sub get_my_handler {
             $init->(\%spec);
         }
         elsif (ref($init) eq "HASH") {
-            while (my($k, $v) = each %$init) {
-                $spec{$k} = $v;
-            }
+            $spec{$_}= $init->{$_}
+                for keys %$init;
         }
         $spec{callback} ||= sub {};
         $spec{line} ||= join(":", (caller)[1,2]);
@@ -1098,15 +1098,28 @@ sub env_proxy {
     my ($self) = @_;
     require Encode;
     require Encode::Locale;
-    my($k,$v);
-    while(($k, $v) = each %ENV) {
-	if ($ENV{REQUEST_METHOD}) {
-	    # Need to be careful when called in the CGI environment, as
-	    # the HTTP_PROXY variable is under control of that other guy.
-	    next if $k =~ /^HTTP_/;
-	    $k = "HTTP_PROXY" if $k eq "CGI_HTTP_PROXY";
-	}
+    my $env_request_method= $ENV{REQUEST_METHOD};
+    my %seen;
+    foreach my $k (sort keys %ENV) {
+        my $real_key= $k;
+        my $v= $ENV{$k}
+            or next;
+        if ( $env_request_method ) {
+            # Need to be careful when called in the CGI environment, as
+            # the HTTP_PROXY variable is under control of that other guy.
+            next if $k =~ /^HTTP_/;
+            $k = "HTTP_PROXY" if $k eq "CGI_HTTP_PROXY";
+        }
 	$k = lc($k);
+        if (my $from_key= $seen{$k}) {
+            warn "Environment contains multiple differing definitions for '$k'.\n".
+                 "Using value from '$from_key' ($ENV{$from_key}) and ignoring '$real_key' ($v)"
+                if $v ne $ENV{$from_key};
+            next;
+        } else {
+            $seen{$k}= $real_key;
+        }
+
 	next unless $k =~ /^(.*)_proxy$/;
 	$k = $1;
 	if ($k eq 'no') {


### PR DESCRIPTION
This is a rebased and slightly edited version of https://github.com/gisle/libwww-perl/pull/3 by @demerphq 

Audited and fixed any potential hash order dependency bugs in
LWP::UserAgent. I replaced all the uses of each() with keys() to avoid
hash iterator state bugs, and made sure that keys are sorted where
their order might matter, which was as far as I could tell only in
how proxy configuration was read from the envrionment.

There was ambiguity as to which of $ENV{http_proxy} and
$ENV{HTTP_PROXY} would be chosen by LWP::UserAgent->env_proxy(). We now
choose HTTP_PROXY if both are set, and if they differ we warn about
the conflicting configuration.

This patch includes tests to check that we warn on conflicting config
and that we correctly handle setting via either.

This includes a version bump to 6.05.

See also:

libwww-perl RT Ticket
    https://rt.cpan.org/Ticket/Display.html?id=81381

bleadperl 5.17.6 patch (queued for 5.18):
    http://perl5.git.perl.org/perl.git/commit/7dc8663964c66a698d31bbdc8e8abed69bddeec3

Eliminating the "rehash" mechanism for 5.18
    http://www.nntp.perl.org/group/perl.perl5.porters/2012/10/msg194813.html

Switch perl's hash function to MurmurHash-32 (v3) and hash randomization by default.
    http://www.nntp.perl.org/group/perl.perl5.porters/2012/11/msg195492.html