### PR TITLE
require HTTP::Daemon 6.12 for test

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Require HTTP::Daemon 6.12 for test (GH#374, GH#375) (fitzmorrispr, skaji)
 
 6.52      2021-01-07 21:20:51Z
     - Remove block of code which creates message-digest auth request field

--- a/cpanfile
+++ b/cpanfile
@@ -19,7 +19,6 @@ on 'runtime' => sub {
     requires 'HTML::Entities';
     requires 'HTML::HeadParser';
     requires 'HTTP::Cookies' => '6';
-    requires 'HTTP::Daemon' => '6';
     requires 'HTTP::Date' => '6';
     requires 'HTTP::Negotiate' => '6';
     requires 'HTTP::Request' => '6';
@@ -44,6 +43,7 @@ on 'runtime' => sub {
 };
 
 on 'test' => sub {
+    requires 'HTTP::Daemon' => '6.12';
     requires 'Test::Fatal';
     requires 'Test::More', '0.96';
     requires 'Test::RequiresInternet';


### PR DESCRIPTION
This PR does two things:

* Fix #374. Requires HTTP::Daemon 6.12
* HTTP::Daemon is used only in `t/*.t`. So change it from runtime-require to test-require.