### PR TITLE
Be explicit in the prerequisite of HTTP::Status

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -10,6 +10,7 @@ use HTTP::Response ();
 use HTTP::Date ();
 
 use LWP ();
+use HTTP::Status ();
 use LWP::Protocol ();
 
 use Scalar::Util qw(blessed);


### PR DESCRIPTION
See https://perlmonks.org/?node_id=11132138 , which is weird code
and shouldn't fail, but maybe fails in persistent environments
like Apache.