### PR TITLE
When a truthy Content-Type is provided, override the default

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -445,38 +445,40 @@ sub get {
     return $self->request( HTTP::Request::Common::GET( @parameters ), @suff );
 }
 
-sub _has_raw_content {
+sub _maybe_copy_default_content_type {
     my $self = shift;
-    shift; # drop url
+    my $req = shift;
 
-    # taken from HTTP::Request::Common::request_type_with_data
+    my $default_ct = $self->default_header('Content-Type');
+    return unless defined $default_ct;
+
+    # drop url
+    shift;
+
+    # adapted from HTTP::Request::Common::request_type_with_data
     my $content;
     $content = shift if @_ and ref $_[0];
+
+    # We only care about the final value, really
+    my $ct;
+
     my($k, $v);
     while (($k,$v) = splice(@_, 0, 2)) {
         if (lc($k) eq 'content') {
             $content = $v;
+        } elsif (lc($k) eq 'content-type') {
+            $ct = $v;
         }
     }
 
-    # We were given Content => 'string' ...
-    if (defined $content && ! ref ($content)) {
-        return 1;
-    }
+    # Content-type provided and truthy? skip
+    return if $ct;
 
-    return;
-}
+    # Content is not just a string? Then it must be x-www-form-urlencoded
+    return if defined $content && ref($content);
 
-sub _maybe_copy_default_content_type {
-    my ($self, $req, @parameters) = @_;
-
-    # If we have a default Content-Type and someone passes in a POST/PUT
-    # with Content => 'some-string-value', use that Content-Type instead
-    # of x-www-form-urlencoded
-    my $ct = $self->default_header('Content-Type');
-    return unless defined $ct && $self->_has_raw_content(@parameters);
-
-    $req->header('Content-Type' => $ct);
+    # Provide default
+    $req->header('Content-Type' => $default_ct);
 }
 
 sub post {


### PR DESCRIPTION
If you set up a default_header('Content-Type => '...') but then
do ->post($url, 'Content-Type' => 'foo', Content => "..."), the
provided content type should override the default!

We only override the default if the provided value is truthy though,
as this mirrors how ->post($url, "Content-Type" => 0) behaves.

This fixes a bug in my initial implementation in #100
