### PR TITLE
Add a test for "response_redirect"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Add a test for "response_redirect" (GH#387) (James Raspass)
 
 6.57      2021-09-20 20:20:14Z
     - Update docs for protocols_allowed and protocols forbidden (GH#386) (Olaf Alders)


### PR DESCRIPTION
Seems like quite a novel feature that's worthy of a test.

I tweaked `t/base/ua_handlers.t` slightly to ensure each subtest gets it's own UA to avoid shared state.

This change should slightly increase code coverage :tada: 