### PR TITLE
Replace remaining uses of "base" with "parent"

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Change history for libwww-perl
 {{$NEXT}}
     - Add a test for "response_redirect" (GH#387) (James Raspass)
     - Documentation fixes (Julien Fiegehenn)
+    - Replace remaining uses of "base" with "parent" (GH#389) (James Raspass)
 
 6.57      2021-09-20 20:20:14Z
     - Update docs for protocols_allowed and protocols forbidden (GH#386) (Olaf Alders)

--- a/META.json
+++ b/META.json
@@ -77,7 +77,7 @@
             "URI" : "1.10",
             "URI::Escape" : "0",
             "WWW::RobotRules" : "6",
-            "base" : "0",
+            "parent" : "0.217",
             "perl" : "5.008001",
             "strict" : "0",
             "warnings" : "0"
@@ -1038,4 +1038,3 @@
    "x_serialization_backend" : "Cpanel::JSON::XS version 4.04",
    "x_spdx_expression" : "Artistic-1.0-Perl OR GPL-1.0-or-later"
 }
-

--- a/bin/lwp-request
+++ b/bin/lwp-request
@@ -226,7 +226,7 @@ my %options;
 
     use strict;
     use warnings;
-    use base qw(LWP::UserAgent);
+    use parent qw(LWP::UserAgent);
 
     sub new {
         my $self = LWP::UserAgent::new(@_);

--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ on 'runtime' => sub {
     requires 'perl' => '5.008001';
     requires 'strict';
     requires 'warnings';
-    requires 'base';
+    requires 'parent' => '0.217';
     requires 'Digest::MD5';
     requires 'Encode' => '2.12';
     requires 'Encode::Locale';

--- a/lib/LWP/Authen/Digest.pm
+++ b/lib/LWP/Authen/Digest.pm
@@ -1,7 +1,7 @@
 package LWP::Authen::Digest;
 
 use strict;
-use base 'LWP::Authen::Basic';
+use parent 'LWP::Authen::Basic';
 
 our $VERSION = '6.58';
 

--- a/lib/LWP/Debug/TraceHTTP.pm
+++ b/lib/LWP/Debug/TraceHTTP.pm
@@ -9,7 +9,7 @@ package LWP::Debug::TraceHTTP;
 # programs that use LWP.
 
 use strict;
-use base 'LWP::Protocol::http';
+use parent 'LWP::Protocol::http';
 
 our $VERSION = '6.58';
 

--- a/lib/LWP/MemberMixin.pm
+++ b/lib/LWP/MemberMixin.pm
@@ -23,7 +23,7 @@ LWP::MemberMixin - Member access mixin class
 =head1 SYNOPSIS
 
  package Foo;
- use base qw(LWP::MemberMixin);
+ use parent qw(LWP::MemberMixin);
 
 =head1 DESCRIPTION
 

--- a/lib/LWP/Protocol.pm
+++ b/lib/LWP/Protocol.pm
@@ -1,6 +1,6 @@
 package LWP::Protocol;
 
-use base 'LWP::MemberMixin';
+use parent 'LWP::MemberMixin';
 
 our $VERSION = '6.58';
 
@@ -210,7 +210,7 @@ LWP::Protocol - Base class for LWP protocols
 =head1 SYNOPSIS
 
  package LWP::Protocol::foo;
- use base qw(LWP::Protocol);
+ use parent qw(LWP::Protocol);
 
 =head1 DESCRIPTION
 

--- a/lib/LWP/Protocol/cpan.pm
+++ b/lib/LWP/Protocol/cpan.pm
@@ -2,7 +2,7 @@ package LWP::Protocol::cpan;
 
 use strict;
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 our $VERSION = '6.58';
 

--- a/lib/LWP/Protocol/data.pm
+++ b/lib/LWP/Protocol/data.pm
@@ -9,7 +9,7 @@ our $VERSION = '6.58';
 require HTTP::Response;
 require HTTP::Status;
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 use HTTP::Date qw(time2str);
 require LWP;  # needs version number

--- a/lib/LWP/Protocol/file.pm
+++ b/lib/LWP/Protocol/file.pm
@@ -1,6 +1,6 @@
 package LWP::Protocol::file;
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 use strict;
 

--- a/lib/LWP/Protocol/ftp.pm
+++ b/lib/LWP/Protocol/ftp.pm
@@ -2,7 +2,7 @@ package LWP::Protocol::ftp;
 
 # Implementation of the ftp protocol (RFC 959). We let the Net::FTP
 # package do all the dirty work.
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 use strict;
 
 our $VERSION = '6.58';
@@ -21,7 +21,7 @@ use File::Listing   ();
         LWP::Protocol::MyFTP;
 
     use strict;
-    use base qw(Net::FTP);
+    use parent qw(Net::FTP);
 
     sub new {
         my $class = shift;

--- a/lib/LWP/Protocol/gopher.pm
+++ b/lib/LWP/Protocol/gopher.pm
@@ -16,7 +16,7 @@ require HTTP::Status;
 require IO::Socket;
 require IO::Select;
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 
 my %gopher2mimetype = (

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -8,7 +8,7 @@ require HTTP::Response;
 require HTTP::Status;
 require Net::HTTP;
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 our @EXTRA_SOCK_OPTS;
 my $CRLF = "\015\012";

--- a/lib/LWP/Protocol/loopback.pm
+++ b/lib/LWP/Protocol/loopback.pm
@@ -6,7 +6,7 @@ our $VERSION = '6.58';
 
 require HTTP::Response;
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 sub request {
     my($self, $request, $proxy, $arg, $size, $timeout) = @_;

--- a/lib/LWP/Protocol/mailto.pm
+++ b/lib/LWP/Protocol/mailto.pm
@@ -13,7 +13,7 @@ use strict;
 
 our $VERSION = '6.58';
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 our $SENDMAIL;
 
 unless ($SENDMAIL = $ENV{SENDMAIL}) {

--- a/lib/LWP/Protocol/nntp.pm
+++ b/lib/LWP/Protocol/nntp.pm
@@ -2,7 +2,7 @@ package LWP::Protocol::nntp;
 
 # Implementation of the Network News Transfer Protocol (RFC 977)
 
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 our $VERSION = '6.58';
 

--- a/lib/LWP/Protocol/nogo.pm
+++ b/lib/LWP/Protocol/nogo.pm
@@ -11,7 +11,7 @@ our $VERSION = '6.58';
 
 require HTTP::Response;
 require HTTP::Status;
-use base qw(LWP::Protocol);
+use parent qw(LWP::Protocol);
 
 sub request {
     my($self, $request) = @_;

--- a/lib/LWP/RobotUA.pm
+++ b/lib/LWP/RobotUA.pm
@@ -1,6 +1,6 @@
 package LWP::RobotUA;
 
-use base qw(LWP::UserAgent);
+use parent qw(LWP::UserAgent);
 
 our $VERSION = '6.58';
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -2,7 +2,7 @@ package LWP::UserAgent;
 
 use strict;
 
-use base qw(LWP::MemberMixin);
+use parent qw(LWP::MemberMixin);
 
 use Carp ();
 use HTTP::Request ();

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -448,7 +448,7 @@ sub _test {
 
 {
     package MyUA;
-    use base 'LWP::UserAgent';
+    use parent 'LWP::UserAgent';
     sub get_basic_credentials {
         my($self, $realm, $uri, $proxy) = @_;
         if ($realm eq "libwww-perl" && $uri->rel($base) eq "basic") {
@@ -459,7 +459,7 @@ sub _test {
 }
 {
     package MyUA4;
-    use base 'LWP::UserAgent';
+    use parent 'LWP::UserAgent';
     sub get_basic_credentials {
         my($self, $realm, $uri, $proxy) = @_;
         if ($realm eq "libwww-perl-utf8" && $uri->rel($base)->path eq "basic_utf8") {
@@ -470,7 +470,7 @@ sub _test {
 }
 {
     package MyUA2;
-    use base 'LWP::UserAgent';
+    use parent 'LWP::UserAgent';
     sub get_basic_credentials {
         my($self, $realm, $uri, $proxy) = @_;
         if ($realm eq "libwww-perl-digest" && $uri->rel($base) eq "digest") {
@@ -481,7 +481,7 @@ sub _test {
 }
 {
     package MyUA3;
-    use base 'LWP::UserAgent';
+    use parent 'LWP::UserAgent';
     sub get_basic_credentials {
         my($self, $realm, $uri, $proxy) = @_;
         return ("irrelevant", "xyzzy");

--- a/t/local/httpsub.t
+++ b/t/local/httpsub.t
@@ -23,7 +23,7 @@ exit;
 
 {
     package myhttp;
-    use base 'LWP::Protocol::http';
+    use parent 'LWP::Protocol::http';
 
     sub _conn_class {
         "myconn";
@@ -88,5 +88,6 @@ exit;
 }
 {
     package myhttp::Socket;
-    use base qw(myhttp::SocketMethods Net::HTTP);
+    use parent -norequire => qw(myhttp::SocketMethods);
+    use parent qw(Net::HTTP);
 }

--- a/t/local/protosub.t
+++ b/t/local/protosub.t
@@ -30,7 +30,7 @@ exit;
 
 {
     package myhttp;
-    use base 'LWP::Protocol';
+    use parent 'LWP::Protocol';
     use Test::More;
 
     sub new {

--- a/xt/author/live/jigsaw/auth-b.t
+++ b/xt/author/live/jigsaw/auth-b.t
@@ -10,7 +10,7 @@ plan tests => 9;
 
 {
     package MyUA;
-    use base 'LWP::UserAgent';
+    use parent 'LWP::UserAgent';
 
     my @try = (['foo', 'bar'], ['', ''], ['guest', ''], ['guest', 'guest']);
 

--- a/xt/author/live/jigsaw/auth-d.t
+++ b/xt/author/live/jigsaw/auth-d.t
@@ -9,7 +9,7 @@ use LWP::UserAgent;
 {
 
     package MyUA;
-    use base 'LWP::UserAgent';
+    use parent 'LWP::UserAgent';
 
     my @try = (['foo', 'bar'], ['', ''], ['guest', ''], ['guest', 'guest']);
 


### PR DESCRIPTION
Base says 
> Unless you are using the fields pragma, consider this module discouraged in favor of the lighter-weight parent.

We aren't using fields so let's follow their advice, parent is also core in 5.10+.

We were already using parent in one place (Protocol::http) though it was undeclared in our deps so this fixes that. Depend on the minimum version to support `-norequire`.