### PR TITLE
Use American English aspell master dictionary for POD spelling tests

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -114,7 +114,7 @@ trustme = LWP::RobotUA => qr/^host_count$/
 
 [Test::PodSpelling]
 wordlist = Pod::Wordlist
-spell_cmd = aspell list
+spell_cmd = aspell --master=en_US list
 stopword = afPuUsSedvhx
 stopword = Accomazzi
 stopword = Alexandre


### PR DESCRIPTION
Locale settings affect the choice of aspell's dictionary unless one is explicitly set.

Refs https://github.com/libwww-perl/libwww-perl/pull/393#issuecomment-970301100