### PR TITLE
Warn if updating modification time of mirrored file fails

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Warn if updating modification time of mirrored file fails (GH#399) (Ville Skyttä)
 
 6.59      2021-12-02 21:16:04Z
     - Use American English aspell master dictionary for POD spelling tests (GH#394) (Ville Skyttä)

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1041,7 +1041,8 @@ sub mirror
 
             # make sure the file has the same last modification time
             if ( my $lm = $response->last_modified ) {
-                utime $lm, $lm, $file;
+                utime $lm, $lm, $file
+                    or warn "Cannot update modification time of '$file': $!\n";
             }
         }
     }


### PR DESCRIPTION
Closes #395.

Logging what was the timestamp we tried to set could be useful. No strong opinions whether to do that and how to format it in the error message; suggestions welcome, and actually feel free to modify this branch directly, no need to run that by me :)