### PR TITLE
Allow downloading to a filehandle

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Allow downloading to a filehandle (GH#400) (Andrew Fresh)
 
 6.60      2021-12-17 22:29:57Z
     - Mirror temporary file handling fixes (GH#393) (Ville Skyttä)

--- a/lib/LWP/Protocol.pm
+++ b/lib/LWP/Protocol.pm
@@ -113,7 +113,7 @@ sub collect
             }
             elsif (defined(openhandle($arg)) || !ref($arg) && length($arg)) {
                 my $existing_fh = defined(openhandle($arg));
-                my $mode = $existing_fh ? '>&' : '>';
+                my $mode = $existing_fh ? '>&=' : '>';
                 open(my $fh, $mode, $arg) or die "Can't write to '$arg': $!";
                 binmode($fh);
                 push(@{$response->{handlers}{response_data}}, {
@@ -124,7 +124,9 @@ sub collect
                 });
                 push(@{$response->{handlers}{response_done}}, {
                     callback => sub {
-                        close($fh) or die "Can't write to '$arg': $!";
+                        unless ($existing_fh) {
+                            close($fh) or die "Can't write to '$arg': $!";
+                        }
                         undef($fh);
                     },
                 });

--- a/lib/LWP/Protocol.pm
+++ b/lib/LWP/Protocol.pm
@@ -265,6 +265,7 @@ specified scheme is not supported.
     $response = $protocol->request($request, $proxy, undef);
     $response = $protocol->request($request, $proxy, '/tmp/sss');
     $response = $protocol->request($request, $proxy, \&callback, 1024);
+    $response = $protocol->request($request, $proxy, $fh);
 
 Dispatches a request over the protocol, and returns a response
 object. This method needs to be overridden in subclasses.  Refer to
@@ -281,6 +282,8 @@ file, or by calling a callback. If the first parameter is undefined, then the
 content is stored within the C<$response>. If it's a simple scalar, then it's
 interpreted as a file name and the content is written to this file.  If it's a
 code reference, then content is passed to this routine.
+If it is a filehandle, or similar, such as a L<File::Temp> object,
+content will be written to it.
 
 The collector is a routine that will be called and which is
 responsible for returning pieces (as ref to scalar) of the content to

--- a/lib/LWP/Protocol.pm
+++ b/lib/LWP/Protocol.pm
@@ -8,6 +8,7 @@ use strict;
 use Carp ();
 use HTTP::Status ();
 use HTTP::Response ();
+use Scalar::Util qw(openhandle);
 use Try::Tiny qw(try catch);
 
 my %ImplementedBy = (); # scheme => classname
@@ -110,8 +111,10 @@ sub collect
             if (!defined($arg) || !$response->is_success) {
                 $response->{default_add_content} = 1;
             }
-            elsif (!ref($arg) && length($arg)) {
-                open(my $fh, ">", $arg) or die "Can't write to '$arg': $!";
+            elsif (defined(openhandle($arg)) || !ref($arg) && length($arg)) {
+                my $existing_fh = defined(openhandle($arg));
+                my $mode = $existing_fh ? '>&' : '>';
+                open(my $fh, $mode, $arg) or die "Can't write to '$arg': $!";
                 binmode($fh);
                 push(@{$response->{handlers}{response_data}}, {
                     callback => sub {

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -173,9 +173,12 @@ the HTTP response code.
 =head2 getstore
 
     my $code = getstore($url, $file)
+    my $code = getstore($url, $filehandle)
 
 Gets a document identified by a URL and stores it in the file. The
 return value is the HTTP response code.
+You may also pass a writeable filehandle or similar,
+such as a L<File::Temp> object.
 
 =head2 mirror
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1854,13 +1854,15 @@ Fields names that start with ":" are special.  These will not
 initialize headers of the request but will determine how the response
 content is treated.  The following special field names are recognized:
 
-    ':content_file'   => $filename
+    ':content_file'   => $filename # or $filehandle
     ':content_cb'     => \&callback
     ':read_size_hint' => $bytes
 
-If a C<$filename> is provided with the C<:content_file> option, then the
-response content will be saved here instead of in the response
-object.  If a callback is provided with the C<:content_cb> option then
+If a C<$filename> or C<$filehandle> is provided with the C<:content_file>
+option, then the response content will be saved here instead of in
+the response object.  The C<$filehandle> may also be an object with
+an open file descriptor, such as a L<File::Temp> object.
+If a callback is provided with the C<:content_cb> option then
 this function will be called for each chunk of the response content as
 it is received from the server.  If neither of these options are
 given, then the response content will accumulate in the response

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -13,7 +13,7 @@ use LWP ();
 use HTTP::Status ();
 use LWP::Protocol ();
 
-use Scalar::Util qw(blessed);
+use Scalar::Util qw(blessed openhandle);
 use Try::Tiny qw(try catch);
 
 our $VERSION = '6.61';
@@ -557,11 +557,13 @@ sub _process_colonic_headers {
 	    # Some sanity-checking...
 	    Carp::croak("A :content_file value can't be undef")
 		unless defined $arg;
-	    Carp::croak("A :content_file value can't be a reference")
-		if ref $arg;
-	    Carp::croak("A :content_file value can't be \"\"")
-		unless length $arg;
 
+	    unless ( defined openhandle($arg) ) {
+		    Carp::croak("A :content_file value can't be a reference")
+			if ref $arg;
+		    Carp::croak("A :content_file value can't be \"\"")
+			unless length $arg;
+	    }
 	}
 	elsif ($args->[$i] eq ':read_size_hint') {
 	    $size = $args->[$i + 1];

--- a/t/local/download_to_fh.t
+++ b/t/local/download_to_fh.t
@@ -20,6 +20,17 @@ $dst->seek(0,0);
 is $dst->getline, "Test\n",
     "getstore mirrored into the \$dst filehandle";
 
+TODO: { local $TODO = "mirror should support filehandles";
+$dst = File::Temp->new("dst-XXXXXXXXX");
+$src->printflush(''); # update timestamp
+is LWP::Simple::mirror("file:$src", $dst), 200,
+    "Successful getstore into a File::Temp object";
+
+$dst->seek(0,0);
+is $dst->getline, "Test\n",
+    "getstore mirrored into the \$dst filehandle";
+}
+
 $dst = File::Temp->new("dst-XXXXXXXXX");
 my $res = LWP::UserAgent->new
     ->get("file:$src", ':content_file' => $dst);

--- a/t/local/download_to_fh.t
+++ b/t/local/download_to_fh.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+
+use File::Temp;
+use LWP::UserAgent;
+use LWP::Simple;
+require LWP::Protocol::file;
+
+my $src = File::Temp->new("src-XXXXXXXXX");
+my $dst = File::Temp->new("dst-XXXXXXXXX");
+
+$src->printflush("Test\n");
+$src->close;
+
+is LWP::Simple::getstore("file:$src", $dst), 200,
+    "Successful getstore into a File::Temp object";
+
+$dst->seek(0,0);
+is $dst->getline, "Test\n",
+    "getstore mirrored into the \$dst filehandle";
+
+$dst = File::Temp->new("dst-XXXXXXXXX");
+my $res = LWP::UserAgent->new
+    ->get("file:$src", ':content_file' => $dst);
+
+$dst->seek(0,0);
+is $dst->getline, "Test\n",
+    "\$ua->get with :content_file into the \$dst filehandle";
+
+done_testing;


### PR DESCRIPTION
By checking that it "looks like a name" as well as if it is an openhandle.  If it is a filehandle, we "dup" it instead of opening directly.

This allows us to avoid some possible race conditions and should resolve #362 and be able to use the more secure idiom in #393 .  I think it would also cause the problem described in #292 to no longer error.