### PR TITLE
Require Getopt::Long at runtime, too

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,6 +16,7 @@ on 'runtime' => sub {
     requires 'Encode' => '2.12';
     requires 'Encode::Locale';
     requires 'File::Listing' => '6';
+    requires 'Getopt::Long';
     requires 'HTML::Entities';
     requires 'HTML::HeadParser';
     requires 'HTTP::Cookies' => '6';


### PR DESCRIPTION
`lwp-*` scripts use it.