### PR TITLE
meta refresh redirect

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Redirect on meta refresh (GH#409) (grr)
 
 6.62      2022-04-05 01:04:17Z
     - Allow downloading to a filehandle (GH#400) (Andrew Fresh)

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -303,7 +303,7 @@ sub request {
     $response->previous($previous) if $previous;
 
     if ($response->redirects >= $self->{max_redirect}) {
-        if ($response->header('Location')) {
+        if ($response->header('Location') or $response->header('Refresh')) {
             $response->header("Client-Warning" =>
                 "Redirect loop detected (max_redirect = $self->{max_redirect})"
             );
@@ -773,8 +773,7 @@ sub parse_head {
                 push(@{$response->{handlers}{response_redirect}}, {
                     callback => sub {
                         my ($res, $ua, $handler, $data) = @_;
-                        my ($refresh) = $res->remove_header('refresh')
-                            or return;
+                        my $refresh = $res->header('refresh') or return;
                         my ($url) = $refresh =~ /;\s*url\s*=\s*['"]?([^"'>]+)/i
                             or return;
                         require HTML::Entities;

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -64,7 +64,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 130;
+    plan tests => 134;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -229,6 +229,15 @@ sub _test {
         is($ua->max_redirect(), 5, 'redirect loop: max redirect 5');
         $res = $ua->request($req);
         isa_ok($res, 'HTTP::Response', 'redirect loop: good response object');
+    }
+    { # meta refresh
+        my $req = HTTP::Request->new(GET => url("/meta_refresh", $base));
+        my $res = $ua->request($req);
+
+        ok($res->is_success, 'meta_refresh: is_success');
+        like($res->content, qr|/echo/meta_refresh|, 'meta_refresh: content good');
+        is($res->previous->code, 200, 'meta_refresh: code 200');
+        is($res->redirects, 1, 'meta_refresh redirect count: 1');
     }
     { # basic auth
         my $req = HTTP::Request->new(GET => url("/basic", $base));
@@ -645,6 +654,20 @@ sub daemonize {
     $router{get_redirect2} = sub { shift->send_redirect("/redirect3/") };
     $router{get_redirect3} = sub { shift->send_redirect("/redirect2/") };
     $router{get_redirect4} = sub { my $r = HTTP::Response->new(303); shift->send_response($r) };
+    $router{get_meta_refresh} = sub {
+        my($c,$r) = @_;
+        $c->send_basic_header;
+        $c->print("Content-Type: text/html");
+        $c->send_crlf;
+        $c->send_crlf;
+        $c->print(<<'        HTML');
+            <html>
+            <head>
+            <meta http-equiv='refresh' content='0; url=/echo/meta_refresh' />
+            </head>
+            </html>
+        HTML
+    };
     $router{post_echo} = sub {
         my($c,$r) = @_;
         $c->send_basic_header;

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -64,7 +64,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 134;
+    plan tests => 136;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -238,6 +238,12 @@ sub _test {
         like($res->content, qr|/echo/meta_refresh|, 'meta_refresh: content good');
         is($res->previous->code, 200, 'meta_refresh: code 200');
         is($res->redirects, 1, 'meta_refresh redirect count: 1');
+
+        $ua->max_redirect(0);
+        $res = $ua->request($req);
+        is($res->redirects, 0, 'meta_refresh redirect loop: 0 redirects');
+        like($res->header("Client-Warning"), qr/loop detected/i, 'meta_refresh redirect loop: client warning');
+        $ua->max_redirect(5);
     }
     { # basic auth
         my $req = HTTP::Request->new(GET => url("/basic", $base));


### PR DESCRIPTION
Satisfies #239

I noticed two existing issues with the headparser code, neither of which I have addressed in this commit:

1. https://github.com/libwww-perl/libwww-perl/issues/196)
2. Noscript tags are valid within the head tag, and they can contain meta tags. So it's possible to have two sets of contradictory meta tags. We can either:
    * ignore noscript: `$parser->ignore_elements('noscript');`
    * or distinguish the meta tags found in noscript by prefixing/suffixing them so the user can choose which to use.