### PR TITLE
fix NAME in Makefile.PL

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -65,6 +65,7 @@ header = |        push(@prog, $_);
 header = |    }
 header = |}
 WriteMakefile_arg = EXE_FILES => [ map "bin/$_", @prog ]
+WriteMakefile_arg = NAME => 'LWP'
 
 ; TODO strict and warnings to quiet the kwalitee tests
 ; [Test::Kwalitee]


### PR DESCRIPTION
Due to history, the name of this dist does not match the name of its
primary module, or even any module included. The NAME in the Makefile.PL
needs to match the actual primary module of the dist, but the name of
the dist should not be changed. Dist::Zilla on its own does not provide
a way for these to diverge, but the [MakeMaker::Awesome] plugin does
allow passing in arbitrary additional options. Adding our own NAME
option should override the default provided option, even if both still
end up in the Makefile.PL.