### PR TITLE
Revert automatic follow of meta refresh tags

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Revert automatic follow of meta refresh tags which was added in 6.63
+      (GH#415) (Olaf Alders)
 
 6.65      2022-05-09 18:36:14Z
     - fix NAME in Makefile.PL (GH#413) (Graham Knop)

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -303,7 +303,7 @@ sub request {
     $response->previous($previous) if $previous;
 
     if ($response->redirects >= $self->{max_redirect}) {
-        if ($response->header('Location') or $response->header('Refresh')) {
+        if ($response->header('Location')) {
             $response->header("Client-Warning" =>
                 "Redirect loop detected (max_redirect = $self->{max_redirect})"
             );
@@ -773,7 +773,8 @@ sub parse_head {
                 push(@{$response->{handlers}{response_redirect}}, {
                     callback => sub {
                         my ($res, $ua, $handler, $data) = @_;
-                        my $refresh = $res->header('refresh') or return;
+                        my ($refresh) = $res->remove_header('refresh')
+                            or return;
                         my ($url) = $refresh =~ /;\s*url\s*=\s*['"]?([^"'>]+)/i
                             or return;
                         require HTML::Entities;

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -751,43 +751,26 @@ sub parse_head {
         my $flag = shift;
         my $parser;
         my $old = $self->set_my_handler("response_header", $flag ? sub {
-                my($response, $ua) = @_;
-                require HTML::HeadParser;
-                $parser = HTML::HeadParser->new;
-                $parser->xml_mode(1) if $response->content_is_xhtml;
-                $parser->utf8_mode(1) if $] >= 5.008 && $HTML::Parser::VERSION >= 3.40;
+               my($response, $ua) = @_;
+               require HTML::HeadParser;
+               $parser = HTML::HeadParser->new;
+               $parser->xml_mode(1) if $response->content_is_xhtml;
+               $parser->utf8_mode(1) if $] >= 5.008 && $HTML::Parser::VERSION >= 3.40;
 
-                push(@{$response->{handlers}{response_data}}, {
-                    callback => sub {
-                        return unless $parser;
-                        unless ($parser->parse($_[3])) {
-                            my $h = $parser->header;
-                            my $r = $_[0];
-                            for my $f ($h->header_field_names) {
-                                $r->init_header($f, [$h->header($f)]);
-                            }
-                            undef($parser);
-                        }
-                    },
-                });
-                push(@{$response->{handlers}{response_redirect}}, {
-                    callback => sub {
-                        my ($res, $ua, $handler, $data) = @_;
-                        my ($refresh) = $res->remove_header('refresh')
-                            or return;
-                        my ($url) = $refresh =~ /;\s*url\s*=\s*['"]?([^"'>]+)/i
-                            or return;
-                        require HTML::Entities;
-                        HTML::Entities::decode($url);
-                        my $uri = URI->new_abs($url, $res->request->uri)->canonical;
-                        my $base = $res->request->uri;
-                        my $uri = $base->new_abs($url, $base);
-                        return if $uri == $base;
-                        return HTTP::Request->new(
-                            GET => $uri, [referer => $base]
-                        );
-                    },
-                });
+               push(@{$response->{handlers}{response_data}}, {
+		   callback => sub {
+		       return unless $parser;
+		       unless ($parser->parse($_[3])) {
+			   my $h = $parser->header;
+			   my $r = $_[0];
+			   for my $f ($h->header_field_names) {
+			       $r->init_header($f, [$h->header($f)]);
+			   }
+			   undef($parser);
+		       }
+		   },
+	       });
+
             } : undef,
             m_media_type => "html",
         );

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -778,6 +778,7 @@ sub parse_head {
                             or return;
                         require HTML::Entities;
                         HTML::Entities::decode($url);
+                        my $uri = URI->new_abs($url, $res->request->uri)->canonical;
                         my $base = $res->request->uri;
                         my $uri = $base->new_abs($url, $base);
                         return if $uri == $base;

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -64,7 +64,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 136;
+    plan tests => 134;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -238,12 +238,6 @@ sub _test {
         like($res->content, qr|/echo/meta_refresh|, 'meta_refresh: content good');
         is($res->previous->code, 200, 'meta_refresh: code 200');
         is($res->redirects, 1, 'meta_refresh redirect count: 1');
-
-        $ua->max_redirect(0);
-        $res = $ua->request($req);
-        is($res->redirects, 0, 'meta_refresh redirect loop: 0 redirects');
-        like($res->header("Client-Warning"), qr/loop detected/i, 'meta_refresh redirect loop: client warning');
-        $ua->max_redirect(5);
     }
     { # basic auth
         my $req = HTTP::Request->new(GET => url("/basic", $base));

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -64,7 +64,7 @@ sub _test {
     return plan skip_all => 'We could not talk to our daemon' unless $DAEMON;
     return plan skip_all => 'No base URI' unless $base;
 
-    plan tests => 134;
+    plan tests => 130;
 
     my $ua = LWP::UserAgent->new;
     $ua->agent("Mozilla/0.01 " . $ua->agent);
@@ -229,15 +229,6 @@ sub _test {
         is($ua->max_redirect(), 5, 'redirect loop: max redirect 5');
         $res = $ua->request($req);
         isa_ok($res, 'HTTP::Response', 'redirect loop: good response object');
-    }
-    { # meta refresh
-        my $req = HTTP::Request->new(GET => url("/meta_refresh", $base));
-        my $res = $ua->request($req);
-
-        ok($res->is_success, 'meta_refresh: is_success');
-        like($res->content, qr|/echo/meta_refresh|, 'meta_refresh: content good');
-        is($res->previous->code, 200, 'meta_refresh: code 200');
-        is($res->redirects, 1, 'meta_refresh redirect count: 1');
     }
     { # basic auth
         my $req = HTTP::Request->new(GET => url("/basic", $base));
@@ -654,20 +645,6 @@ sub daemonize {
     $router{get_redirect2} = sub { shift->send_redirect("/redirect3/") };
     $router{get_redirect3} = sub { shift->send_redirect("/redirect2/") };
     $router{get_redirect4} = sub { my $r = HTTP::Response->new(303); shift->send_response($r) };
-    $router{get_meta_refresh} = sub {
-        my($c,$r) = @_;
-        $c->send_basic_header;
-        $c->print("Content-Type: text/html");
-        $c->send_crlf;
-        $c->send_crlf;
-        $c->print(<<'        HTML');
-            <html>
-            <head>
-            <meta http-equiv='refresh' content='0; url=/echo/meta_refresh' />
-            </head>
-            </html>
-        HTML
-    };
     $router{post_echo} = sub {
         my($c,$r) = @_;
         $c->send_basic_header;


### PR DESCRIPTION
- Revert "Remove unused variable introduced in 9d73bc422"
- Revert "Add tests for meta_refresh + max_redirects"
- Revert "Preserve the Refresh header on meta redirect"
- Revert "Add tests for meta refresh redirects"
- Revert "Handle meta refresh redirects"

This also broke WWW::Mechanize::Cached: https://github.com/libwww-perl/WWW-Mechanize-Cached/issues/27

From #toolchain on irc.perl.org

```
Could I get some feedback on https://github.com/libwww-perl/WWW-Mechanize-Cached/pull/28 Specifically https://github.com/libwww-perl/WWW-Mechanize-Cached/pull/28/commits/ab875678759d66300d772e33e19d76d143970ed4
I was getting "Can't store CODE items" errors from Storable when caching HTTP::Response objects.

feels wrong
LWP is leaving a handler in place unexpectedly, when it removes others
also, the PR that added the handler feels wrong
having LWP treat a Refresh header as a redirect seems very wrong

it _might_ be defensible if the delay is specified as 0

yeah, Refresh != redirect
```
