### PR TITLE
Remove undocumented LWP::Version sub

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Remove undocumented LWP::Version sub (GH#416) (James Raspass)
 
 6.66      2022-05-18 16:44:44Z
     - Revert automatic follow of meta refresh tags which was added in 6.63

--- a/lib/LWP.pm
+++ b/lib/LWP.pm
@@ -4,8 +4,6 @@ our $VERSION = '6.67';
 
 require LWP::UserAgent;  # this should load everything you need
 
-sub Version { $VERSION; }
-
 1;
 
 __END__


### PR DESCRIPTION
The same functionality can be achieved with either $LWP::VERSION or LWP->VERSION.