### PR TITLE
Fix `lwp-request` (`/usr/bin/GET`) for files non-ASCII

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Fix `lwp-request` (`/usr/bin/GET`) for files non-ASCII (Fredrick Brennan)
 
 6.68      2023-02-27 19:18:33Z
     - Remove dynamic dependency on HTTP::Status (GH#419) (Graham Knop)

--- a/bin/lwp-request
+++ b/bin/lwp-request
@@ -182,6 +182,9 @@ Gisle Aas <gisle@aas.no>
 
 use strict;
 use warnings;
+use locale;
+require POSIX;
+POSIX::setlocale(&POSIX::LC_ALL, "") and POSIX::setlocale(&POSIX::LC_CTYPE, "");
 
 my $progname = $0;
 $progname =~ s,.*[\\/],,;    # use basename only

--- a/lib/LWP/Protocol/file.pm
+++ b/lib/LWP/Protocol/file.pm
@@ -90,6 +90,8 @@ sub request
 	# Make directory listing
 	require URI::Escape;
 	require HTML::Entities;
+	require POSIX;
+	my $localeenc = POSIX::setlocale(&POSIX::LC_CTYPE) =~ s/.*\.//gr;
         my $pathe = $path . ( $^O eq 'MacOS' ? ':' : '/');
 	for (@files) {
 	    my $furl = URI::Escape::uri_escape($_);
@@ -97,7 +99,7 @@ sub request
                 $furl .= '/';
                 $_ .= '/';
             }
-	    my $desc = HTML::Entities::encode($_);
+	    my $desc = HTML::Entities::encode($_, '<>&"');
 	    $_ = qq{<LI><A HREF="$furl">$desc</A>};
 	}
 	# Ensure that the base URL is "/" terminated
@@ -109,6 +111,7 @@ sub request
 			"<HTML>\n<HEAD>",
 			"<TITLE>Directory $path</TITLE>",
 			"<BASE HREF=\"$base\">",
+			"<META CHARSET=\"$localeenc\">",
 			"</HEAD>\n<BODY>",
 			"<H1>Directory listing of $path</H1>",
 			"<UL>", @files, "</UL>",

--- a/lib/LWP/Protocol/file.pm
+++ b/lib/LWP/Protocol/file.pm
@@ -11,6 +11,7 @@ require HTTP::Request;
 require HTTP::Response;
 require HTTP::Status;
 require HTTP::Date;
+require Encode::Locale;
 
 
 sub request
@@ -91,8 +92,8 @@ sub request
 	require URI::Escape;
 	require HTML::Entities;
 	require POSIX;
-	my $localeenc = POSIX::setlocale(&POSIX::LC_CTYPE) =~ s/.*\.//gr;
-        my $pathe = $path . ( $^O eq 'MacOS' ? ':' : '/');
+	my $localeenc = $Encode::Locale::ENCODING_LOCALE_FS;
+	my $pathe = $path . ( $^O eq 'MacOS' ? ':' : '/');
 	for (@files) {
 	    my $furl = URI::Escape::uri_escape($_);
             if ( -d "$pathe$_" ) {

--- a/t/base/protocols/file.t
+++ b/t/base/protocols/file.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+use utf8;
 use strict;
 use warnings;
 use Test::More tests => 4;

--- a/t/base/protocols/file.t
+++ b/t/base/protocols/file.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+use File::Basename qw(dirname);
+use LWP::Simple qw(get);
+use File::Temp qw(tempfile);
+
+require POSIX;
+POSIX::setlocale(&POSIX::LC_ALL, 'ja_JP.UTF-8');
+
+my $tmp, my $tmpd;
+$tmpd = File::Temp->newdir();
+$tmpd->unlink_on_destroy(1);
+$tmp = File::Temp->new(TEMPLATE => 'wwwdata_tempXXXX',
+                       DIR => $tmpd,
+                       SUFFIX => '.コピペ.test');
+
+open(TMP, '>:utf8', $tmp);
+print TMP 'テスト';
+close(TMP);
+
+## Test default directory output.
+is($tmp->filename =~ /コピペ/, 1);
+my $res = get('file://' . dirname($tmp->filename));
+is(($res =~ m/コピペ/, $&), 'コピペ');
+# Make sure there are no HTML entities.
+isnt(($res =~ m/&/, $&), '&');
+
+## Test file output.
+my $res2 = get('file://' . $tmp->filename);
+is($res2, 'テスト');


### PR DESCRIPTION
Closes libwww-perl/libwww-perl#226. _I think._ This is the first time I've ever tried to patch any FOSS related to Perl.