### PR TITLE
Update CI settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - "*"
-  schedule:
-    - cron: "15 4 * * 0" # Every Sunday morning
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -4,7 +4,7 @@ name: dzil build and test
 on:
   push:
     branches:
-      - "*"
+      - "master"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.38
     steps:
       - uses: actions/checkout@v2
       - name: Run Tests
@@ -37,7 +37,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.38
     steps:
       - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v2
@@ -72,6 +72,8 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
+          - "5.38"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl
@@ -116,6 +118,8 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
+          - "5.38"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl


### PR DESCRIPTION
- Run CI on 5.36 and 5.38
- Only run CI on push when branch is master
- Remove scheduled CI as it can disable the action after inactivity
- Add dependabot to upgrade actions
