### PR TITLE
Making it possible to use IPv6 in https call through https proxy environment (in case of using CONNECT method to create a tunnel)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Making it possible to use IPv6 in https call through https proxy
+      environment (in case of using CONNECT method to create a tunnel) (GH#450)
+      (Dmitriy Shamatrin)
 
 6.72      2023-07-17 22:01:19Z
     - Don't mangle protocol scheme and don't require it to be valid if

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -7,7 +7,6 @@ our $VERSION = '6.73';
 require HTTP::Response;
 require HTTP::Status;
 require Net::HTTP;
-
 use parent qw(LWP::Protocol);
 
 our @EXTRA_SOCK_OPTS;
@@ -152,13 +151,13 @@ sub request
     #   same target
 
     my $ssl_tunnel = $proxy && $url->scheme eq 'https'
-	&& $url->host.":".$url->port;
+	&& $url->host_port();
 
     my ($host,$port) = $proxy
 	? ($proxy->host,$proxy->port)
 	: ($url->host,$url->port);
     my $fullpath =
-	$method eq 'CONNECT' ? $url->host . ":" . $url->port :
+	$method eq 'CONNECT' ? $url->host_port() :
 	$proxy && ! $ssl_tunnel ? $url->as_string :
 	do {
 	    my $path = $url->path_query;


### PR DESCRIPTION
More details are at https://github.com/libwww-perl/libwww-perl/issues/449