### PR TITLE
Simplify code slightly for Perl v5.8+

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Simplify code slightly for Perl v5.8+ (GH#455) (James Raspass)
 
 6.75      2024-01-24 14:29:17Z
     - Update lwp-request to suport PATCH HTTP method (GH#452) (Javier Puche)

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -49,8 +49,7 @@ sub _new_socket
 	die "$status\n\n$@";
     }
 
-    # perl 5.005's IO::Socket does not have the blocking method.
-    eval { $sock->blocking(0); };
+    $sock->blocking(0);
 
     $sock;
 }

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -775,7 +775,7 @@ sub parse_head {
                require HTML::HeadParser;
                $parser = HTML::HeadParser->new;
                $parser->xml_mode(1) if $response->content_is_xhtml;
-               $parser->utf8_mode(1) if $] >= 5.008 && $HTML::Parser::VERSION >= 3.40;
+               $parser->utf8_mode(1) if $HTML::Parser::VERSION >= 3.40;
 
                push(@{$response->{handlers}{response_data}}, {
 		   callback => sub {


### PR DESCRIPTION
Since LWP 6.00 in 2011 we require Perl v5.8.8 or better which makes these checks redundant.