### PR TITLE
Documentation updates for https://github.com/libwww-perl/libwww-perl/issues/448#

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1625,10 +1625,10 @@ defaults to 1.
 
 Please note that that recently the overall effect of this option with regards to 
 SSL handling has changed. As of version 6.11 of LWP::Protocol::https, which is an 
-external module, SSL certifate verifaction was harmonized to behave in sync with 
+external module, SSL certificate verification was harmonized to behave in sync with
 IO::Socket::SSL. With this change, setting this option no longer disables all SSL
-certificate verications, only the hostname checks. To disable SSl verifications the
-SSL_verify_mode option can be disabled using the ssl_opts. For example:  
+certificate verification, only the hostname checks. To disable SSL all verifications,
+the SSL_verify_mode option can be disabled using the ssl_opts attribute. For example:
 C<$ua->ssl_opts(SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE);>
 
 =item C<SSL_ca_file> => $path

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1627,7 +1627,7 @@ Please note that that recently the overall effect of this option with regards to
 SSL handling has changed. As of version 6.11 of LWP::Protocol::https, which is an 
 external module, SSL certificate verification was harmonized to behave in sync with
 IO::Socket::SSL. With this change, setting this option no longer disables all SSL
-certificate verification, only the hostname checks. To disable SSL all verifications,
+certificate verification, only the hostname checks. To disable SSL all verification,
 the SSL_verify_mode option can be disabled using the ssl_opts attribute. For example:
 C<$ua->ssl_opts(SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE);>
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1623,6 +1623,14 @@ This option is initialized from the C<PERL_LWP_SSL_VERIFY_HOSTNAME> environment
 variable.  If this environment variable isn't set; then C<verify_hostname>
 defaults to 1.
 
+Please note that that recently the overall effect of this option with regards to 
+SSL handling has changed. As of version 6.11 of LWP::Protocol::https, which is an 
+external module, SSL certifate verifaction was harmonized to behave in sync with 
+IO::Socket::SSL. With this change, setting this option no longer disables all SSL
+certificate verications, only the hostname checks. To disable SSl verifications the
+SSL_verify_mode option can be disabled using the ssl_opts. For example:  
+C<$ua->ssl_opts(SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE);>
+
 =item C<SSL_ca_file> => $path
 
 The path to a file containing Certificate Authority certificates.

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1627,8 +1627,8 @@ Please note that that recently the overall effect of this option with regards to
 SSL handling has changed. As of version 6.11 of LWP::Protocol::https, which is an 
 external module, SSL certificate verification was harmonized to behave in sync with
 IO::Socket::SSL. With this change, setting this option no longer disables all SSL
-certificate verification, only the hostname checks. To disable SSL all verification,
-the SSL_verify_mode option can be disabled using the ssl_opts attribute. For example:
+certificate verification, only the hostname checks. To disable all verification
+use the C<SSL_verify_mode> option in the C<ssl_opts> attribute. For example:
 C<$ua->ssl_opts(SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE);>
 
 =item C<SSL_ca_file> => $path


### PR DESCRIPTION
Updates to reflect changes with regards to how PERL_LWP_SSL_VERIFY_HOSTNAME no longer disables all SSL verifications

[Issue #448 - $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0 seems to be ignored](https://github.com/libwww-perl/libwww-perl/issues/448#)