### PR TITLE
Fix proxy credentials with special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,10 @@ Calling `no_proxy` without any domains clears the list of domains.
         [ 'http', 'https' ] => 'http://http.example.com:8001/',
     ]);
 
+    # Proxy with authentication:
+    $ua->proxy('http', 'http://username:password@proxy.example.com/');
+    $ua->proxy('http' => 'http://username:password@proxy.example.com/');
+
 Set/retrieve proxy URL for a scheme.
 
 The first form specifies that the URL is to be used as a proxy for
@@ -504,6 +508,8 @@ proxy URL for a single access scheme.
 
 The third form demonstrates setting multiple proxies at once. This is also
 the only form accepted by the constructor.
+
+Note: if proxy credentials contain special characters, they will be encoded.
 
 # HANDLERS
 


### PR DESCRIPTION
Fixes #456

```
me@rogflowx13:~/libwww-perl$ prove -l t/**/
t/base/default_content_type.t .. ok     
t/base/protocols.t ............. ok   
t/base/proxy.t ................. ok     
t/base/proxy_request.t ......... ok   
t/base/simple.t ................ ok   
t/base/ua.t .................... ok    
t/base/ua_handlers.t ........... ok   
t/leak/no_leak.t ............... skipped: Need Test::LeakTrace
t/local/autoload-get.t ......... ok   
t/local/autoload.t ............. ok   
t/local/cookie_jar.t ........... ok   
t/local/download_to_fh.t ....... ok   
t/local/get.t .................. ok   
t/local/http.t ................. ok       
t/local/httpsub.t .............. ok   
t/local/protosub.t ............. ok   
t/robot/ua-get.t ............... ok     
t/robot/ua.t ................... ok     
All tests successful.
Files=18, Tests=314, 26 wallclock secs ( 0.09 usr  0.01 sys +  1.67 cusr  0.39 csys =  2.16 CPU)
Result: PASS

me@rogflowx13:~/libwww-perl$ prove -lv t/base/proxy.t 
t/base/proxy.t .. 
1..20
ok 1 - proxy: with env: ABSURDLY_NAMED_PROXY: no errors
ok 2 - proxy: with env: MY_PROXY: no errors
ok 3 - HTTP_PROXY ignored in CGI environment
ok 4 - substitute CGI_HTTP_PROXY used in CGI environment
ok 5 - expected warning on multiple definitions
ok 6 - No warnings if multiple definitions for 'http_proxy' exist, but with the same value
ok 7 - no_proxy from environment
not ok 8 - No warnings for unrelated environment variables # TODO Test case for GH #372
#   Failed (TODO) test 'No warnings for unrelated environment variables'
#   at t/base/proxy.t line 83.
#     Structures begin differing at:
#          $got->[0] = 'Environment contains multiple differing definitions for 'foo'.
#     Using value from 'FOO' (BAR) and ignoring 'foo' (bar) at /home/me/libwww-perl/lib/LWP/UserAgent.pm line 1186.
#     '
#     $expected->[0] = Does not exist
ok 9 - http_proxy from environment
ok 10 - proxy: user with semicolon: got exception
ok 11 - proxy: password with semicolon: got exception
ok 12 - proxy: no host with env_proxy: got exception
ok 13 - http_proxy from method
ok 14 - proxy: user with semicolon: got exception
ok 15 - proxy: password with semicolon: got exception
ok 16 - proxy: no host: got exception
ok 17 - http_proxy from method
ok 18 - proxy: user with semicolon: got exception
ok 19 - proxy: password with semicolon: got exception
ok 20 - proxy: no host: got exception
ok
All tests successful.
Files=1, Tests=20,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.07 cusr  0.02 csys =  0.11 CPU)
Result: PASS
```