### PR TITLE
Update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
+---
 version: 2
 updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: 'monthly'

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-job:
     name: Build distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: perldocker/perl-tester:5.40
     steps:
@@ -33,7 +33,7 @@ jobs:
           path: build_dir
   coverage-job:
     needs: build-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: perldocker/perl-tester:5.40
     steps:
@@ -50,11 +50,11 @@ jobs:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
   ubuntu-test-job:
     needs: build-job
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         perl-version:
           - "5.14"
           - "5.16"

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -142,8 +142,6 @@ jobs:
       matrix:
         os: [windows-latest]
         perl-version:
-          - "5.14"
-          - "5.16"
           - "5.18"
           - "5.20"
           - "5.22"

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.38
+      image: perldocker/perl-tester:5.40
     steps:
       - uses: actions/checkout@v4
       - name: Run Tests
@@ -35,7 +35,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.38
+      image: perldocker/perl-tester:5.40
     steps:
       - uses: actions/checkout@v4 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v4
@@ -69,6 +69,7 @@ jobs:
           - "5.34"
           - "5.36"
           - "5.38"
+          - "5.40"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl
@@ -112,6 +113,7 @@ jobs:
           - "5.34"
           - "5.36"
           - "5.38"
+          - "5.40"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl


### PR DESCRIPTION
- **Add 5.40 to GH actions**
- **Drop 5.14 from Windows GH actions**
- **Add dependabot config**
- **bump GH actions Ubuntu from 20.04 to 24.04**
