### PR TITLE
don't warn on proxy as unrecognized option for LWP::UserAgent->new

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -73,6 +73,8 @@ sub new
     my $no_proxy = exists $cnf{no_proxy} ? delete $cnf{no_proxy} : [];
     Carp::croak(qq{no_proxy must be an arrayref, not $no_proxy!}) if ref $no_proxy ne 'ARRAY';
 
+    my $proxy = exists $cnf{proxy} ? delete $cnf{proxy} : [];
+
     my $cookie_jar = delete $cnf{cookie_jar};
     my $conn_cache = delete $cnf{conn_cache};
     my $keep_alive = delete $cnf{keep_alive};
@@ -129,10 +131,10 @@ sub new
     $self->parse_head($parse_head);
     $self->env_proxy if $env_proxy;
 
-    if (exists $cnf{proxy}) {
+    if ($proxy) {
         Carp::croak(qq{proxy must be an arrayref, not $cnf{proxy}!})
-            if ref $cnf{proxy} ne 'ARRAY';
-        $self->proxy($cnf{proxy});
+            if ref $proxy ne 'ARRAY';
+        $self->proxy($proxy);
     }
 
     $self->protocols_allowed(  $protocols_allowed  ) if $protocols_allowed;


### PR DESCRIPTION
Upon upgrading from perl 5.36.1 to perl 5.40.1, this error started showing up:
```
Unrecognized LWP::UserAgent options: proxy at /path/to/my/site_perl/5.40.1/LWP/UserAgent.pm line 102.
```

Sure enough, the `new` method seems to very clearly expect for `%cnf` to be empty before ever checking for `$cnf{proxy}`. I'm confused as to how nobody seems to have been hitting this previously.