### PR TITLE
Remove example references to malicious domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,8 +458,8 @@ proxy server.
 Load proxy settings from `*_proxy` environment variables.  You might
 specify proxies like this (sh-syntax):
 
-    gopher_proxy=http://proxy.my.place/
-    wais_proxy=http://proxy.my.place/
+    gopher_proxy=http://proxy.example.org/
+    wais_proxy=http://proxy.example.org/
     no_proxy="localhost,example.com"
     export gopher_proxy wais_proxy no_proxy
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1688,8 +1688,8 @@ proxy server.
 Load proxy settings from C<*_proxy> environment variables.  You might
 specify proxies like this (sh-syntax):
 
-  gopher_proxy=http://proxy.my.place/
-  wais_proxy=http://proxy.my.place/
+  gopher_proxy=http://proxy.example.org/
+  wais_proxy=http://proxy.example.org/
   no_proxy="localhost,example.com"
   export gopher_proxy wais_proxy no_proxy
 


### PR DESCRIPTION
[Some security vendors are considering `proxy[.]my[.]place` a malicious domain](https://www.virustotal.com/gui/domain/proxy.my.place/detection), causing `UserAgent.pm` to get flagged as potential malware by their scans. Updating the example documentation in `UserAgent.pm` and the `README` that includes this domain to avoid any confusion.