### PR TITLE
Fix env_proxy() warning for unrelated environment variables

### DIFF
--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1169,9 +1169,12 @@ sub env_proxy {
         }
 	$k = lc($k);
         if (my $from_key= $seen{$k}) {
-            warn "Environment contains multiple differing definitions for '$k'.\n".
-                 "Using value from '$from_key' ($ENV{$from_key}) and ignoring '$real_key' ($v)"
-                if $v ne $ENV{$from_key};
+            # Only warn about proxy-related env vars, not unrelated ones (GH #372)
+            if ($k =~ /^(.*)_proxy$/) {
+                warn "Environment contains multiple differing definitions for '$k'.\n".
+                     "Using value from '$from_key' ($ENV{$from_key}) and ignoring '$real_key' ($v)"
+                    if $v ne $ENV{$from_key};
+            }
             next;
         } else {
             $seen{$k}= $real_key;

--- a/t/base/proxy.t
+++ b/t/base/proxy.t
@@ -73,7 +73,6 @@ SKIP: {
 }
 
 {
-    local $TODO = "Test case for GH #372";
     my @warnings;
     local $SIG{__WARN__}   = sub { push @warnings, @_ };
     local $ENV{FOO} = 'BAR';


### PR DESCRIPTION
Only warn about case-insensitive duplicate environment variables when
they are proxy-related (*_proxy). Previously, env_proxy() warned about
any duplicate env vars (e.g. FOO/foo), even on case-sensitive systems
and for variables LWP never reads.

The test coverage for this was added in GH #383 (v6.56) as a TODO test,
but the actual fix was never implemented. Remove the TODO marker now
that the test passes.

Based on a patch by @kberry.

Closes #372
