### PR TITLE
Allow LWP::UserAgent to send headers on CONNECT requests

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,7 +3,8 @@ Change history for libwww-perl
 {{$NEXT}}
     - Add proxy_header() and proxy_headers() to LWP::UserAgent so that
       headers can be sent on the CONNECT request used to tunnel HTTPS
-      through an HTTP proxy (GH#505) (Mathias Fischer, Olaf Alders).
+      through an HTTP proxy. proxy_headers may also be passed to the
+      constructor (GH#505) (Mathias Fischer, Olaf Alders).
 
 6.82      2026-03-29 17:02:10Z
     - Fix env_proxy() warning for unrelated environment variables (GH#501)

--- a/Changes
+++ b/Changes
@@ -4,7 +4,7 @@ Change history for libwww-perl
     - Add proxy_header() and proxy_headers() to LWP::UserAgent so that
       headers can be sent on the CONNECT request used to tunnel HTTPS
       through an HTTP proxy. proxy_headers may also be passed to the
-      constructor (GH#505) (Mathias Fischer, Olaf Alders).
+      constructor (GH#505) (Mathias Fischer, Olaf Alders, Claude).
 
 6.82      2026-03-29 17:02:10Z
     - Fix env_proxy() warning for unrelated environment variables (GH#501)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Add proxy_header() and proxy_headers() to LWP::UserAgent so that
+      headers can be sent on the CONNECT request used to tunnel HTTPS
+      through an HTTP proxy (GH#505) (Mathias Fischer, Olaf Alders).
 
 6.82      2026-03-29 17:02:10Z
     - Fix env_proxy() warning for unrelated environment variables (GH#501)

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -196,8 +196,9 @@ sub request
 	# a plain socket to SSL. In case of Net::SSL we fall back to
 	# the old version
 	if ( my $upgrade_sub = $proto_https->can('_upgrade_sock')) {
+	    my $proxy_headers = $self->{ua}->can('proxy_headers') ? $self->{ua}->proxy_headers() : undef;
 	    my $response = $self->request(
-		HTTP::Request->new('CONNECT',"http://$ssl_tunnel"),
+		HTTP::Request->new('CONNECT',"http://$ssl_tunnel", $proxy_headers),
 		$proxy,
 		undef,$size,$timeout
 	    );

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -195,8 +195,8 @@ sub request
 	# only if ssl socket class is IO::Socket::SSL we can upgrade
 	# a plain socket to SSL. In case of Net::SSL we fall back to
 	# the old version
+	my $proxy_headers = $self->{ua}{proxy_headers};
 	if ( my $upgrade_sub = $proto_https->can('_upgrade_sock')) {
-	    my $proxy_headers = $self->{ua}->can('proxy_headers') ? $self->{ua}->proxy_headers() : undef;
 	    my $response = $self->request(
 		HTTP::Request->new('CONNECT',"http://$ssl_tunnel", $proxy_headers),
 		$proxy,
@@ -208,6 +208,11 @@ sub request
 		$response->{client_socket},$url)
 		or die "SSL upgrade failed: $@";
 	} else {
+	    if ($proxy_headers && $proxy_headers->header_field_names) {
+		die "Cannot send proxy_headers on CONNECT: the active SSL backend "
+		   ."does not support upgrading a plain socket. Install IO::Socket::SSL "
+		   ."(the LWP default) to enable proxy_headers over HTTPS tunnels.\n";
+	    }
 	    $socket = $proto_https->_new_socket($url->host,$url->port,$timeout);
 	}
     }

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -31,6 +31,7 @@ sub new
     my $agent = delete $cnf{agent};
     my $from  = delete $cnf{from};
     my $def_headers = delete $cnf{default_headers};
+    my $proxy_headers = delete $cnf{proxy_headers};
     my $timeout = delete $cnf{timeout};
     $timeout = 3*60 unless defined $timeout;
     my $local_address = delete $cnf{local_address};
@@ -127,6 +128,7 @@ sub new
     $self->agent(defined($agent) ? $agent : $class->_agent)
         if defined($agent) || !$def_headers || !$def_headers->header("User-Agent");
     $self->from($from) if $from;
+    $self->proxy_headers($proxy_headers) if $proxy_headers;
     $self->cookie_jar($cookie_jar) if $cookie_jar;
     $self->parse_head($parse_head);
     $self->env_proxy if $env_proxy;
@@ -1607,9 +1609,6 @@ target server.
 
 See L<LWP::UserAgent/proxy_headers> for the underlying header object.
 
-C<proxy_header> is not accepted as a constructor argument; set it on an
-instance after construction.
-
 =head2 proxy_headers
 
     my $headers = $ua->proxy_headers;
@@ -1621,6 +1620,12 @@ default this will be an empty L<HTTP::Headers> object that is auto-vivified
 on first access. Setting accepts any object that C<< can("header_field_names") >>
 (i.e. an L<HTTP::Headers> or compatible subclass); passing a non-object or
 unblessed reference croaks.
+
+This may also be passed to the constructor:
+
+  my $ua = LWP::UserAgent->new(
+      proxy_headers => HTTP::Headers->new('Proxy-Authorization' => '...'),
+  );
 
 See L<LWP::UserAgent/proxy_header> for setting individual fields and
 L<LWP::UserAgent/default_headers> for the equivalent interface for normal

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -840,6 +840,23 @@ sub cookie_jar {
     return $old;
 }
 
+sub proxy_header {
+    my $self = shift;
+    $self->{proxy_headers} ||= HTTP::Headers->new;
+    return $self->{proxy_headers}->header(@_);
+}
+
+sub proxy_headers {
+    my $self = shift;
+    my $old = $self->{proxy_headers} ||= HTTP::Headers->new;
+    if (@_) {
+	Carp::croak("proxy_headers not set to HTTP::Headers compatible object")
+	    unless @_ == 1 && blessed($_[0]) && $_[0]->can("header_field_names");
+	$self->{proxy_headers} = shift;
+    }
+    return $old;
+}
+
 sub default_headers {
     my $self = shift;
     my $old = $self->{def_headers} ||= HTTP::Headers->new;
@@ -1488,6 +1505,12 @@ The default is to not send a C<From> header.  See
 L<LWP::UserAgent/default_headers> for the more general interface that allow
 any header to be defaulted.
 
+=head2 proxy_headers
+
+    my $headers = $ua->proxy_headers;
+
+Get/set all headers that should be sent to proxies via CONNECT requests.
+
 
 =head2 local_address
 
@@ -1571,6 +1594,13 @@ For example: C<< $ua->protocols_forbidden( [ 'file', 'mailto'] ); >>
 means that this user agent will I<not> allow those protocols, and
 attempts to use this user agent to access URLs with those schemes
 will result in a 500 error.
+
+=head2 proxy_header
+
+    my $value = $ua->proxy_header( $field );
+    $ua->proxy_header( $field => $value );
+
+Get/set headers that will only be sent to proxies via CONNECT requests.
 
 =head2 requests_redirectable
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -128,7 +128,7 @@ sub new
     $self->agent(defined($agent) ? $agent : $class->_agent)
         if defined($agent) || !$def_headers || !$def_headers->header("User-Agent");
     $self->from($from) if $from;
-    $self->proxy_headers($proxy_headers) if $proxy_headers;
+    $self->proxy_headers($proxy_headers) if defined $proxy_headers;
     $self->cookie_jar($cookie_jar) if $cookie_jar;
     $self->parse_head($parse_head);
     $self->env_proxy if $env_proxy;
@@ -844,7 +844,8 @@ sub cookie_jar {
 
 sub proxy_header {
     my $self = shift;
-    $self->{proxy_headers} ||= HTTP::Headers->new;
+    $self->{proxy_headers} ||= HTTP::Headers->new if @_ > 1;
+    return unless $self->{proxy_headers};
     return $self->{proxy_headers}->header(@_);
 }
 
@@ -1361,6 +1362,7 @@ The following options correspond to attribute methods described below:
    protocols_allowed       undef
    protocols_forbidden     undef
    proxy                   {}
+   proxy_headers           HTTP::Headers->new
    requests_redirectable   ['GET', 'HEAD']
    send_te                 1
    show_progress           undef
@@ -1602,12 +1604,17 @@ will result in a 500 error.
 
 Get/set a single header that will be sent to proxies on the C<CONNECT>
 request used when tunneling HTTPS through an HTTP proxy. This is a shortcut
-for C<< $ua->proxy_headers->header( $field => $value ) >> and corresponds to
-curl's C<--proxy-header> option. A typical use is sending
-C<Proxy-Authorization> on the tunnel request without leaking it to the
-target server.
+for C<< $ua->proxy_headers->header( $field => $value ) >>. A typical use is
+sending C<Proxy-Authorization> on the tunnel request without leaking it to
+the target server.
 
-See L<LWP::UserAgent/proxy_headers> for the underlying header object.
+This applies to the C<CONNECT> tunnel only. It is similar in spirit to
+curl's C<--proxy-header> option, though curl applies that flag to all
+requests sent to the proxy (including non-CONNECT proxied requests),
+whereas LWP applies these headers only to the C<CONNECT> request.
+
+See L<LWP::UserAgent/proxy_headers> for the underlying header object and
+the caveats around SSL backends.
 
 =head2 proxy_headers
 
@@ -1630,6 +1637,19 @@ This may also be passed to the constructor:
 See L<LWP::UserAgent/proxy_header> for setting individual fields and
 L<LWP::UserAgent/default_headers> for the equivalent interface for normal
 (non-CONNECT) requests.
+
+B<SSL backend caveat>: C<proxy_headers> are sent only when LWP is using
+L<IO::Socket::SSL> (the default since LWP 6.00). The legacy L<Net::SSL>
+backend (shipped by L<Crypt::SSLeay>) cannot upgrade an existing socket,
+so the C<CONNECT> request is bypassed entirely on that path. To avoid
+silently dropping the headers, LWP will C<die> if you have set
+C<proxy_headers> while the L<Net::SSL> backend is in use.
+
+B<Note on Proxy-Authorization>: if your proxy URL embeds userinfo
+(e.g. C<http://user:pass@proxy:3128>), L<LWP::Protocol::http> will set
+C<Proxy-Authorization> automatically and that value takes precedence over
+anything in C<proxy_headers>. Either set the credentials via the proxy URL
+B<or> via C<proxy_headers>, not both.
 
 =head2 requests_redirectable
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -853,8 +853,10 @@ sub proxy_headers {
     my $self = shift;
     my $old = $self->{proxy_headers} ||= HTTP::Headers->new;
     if (@_) {
-	Carp::croak("proxy_headers not set to HTTP::Headers compatible object")
-	    unless @_ == 1 && blessed($_[0]) && $_[0]->can("header_field_names");
+	my $arg = $_[0];
+	my $desc = defined($arg) ? qq{"$arg"} : 'undef';
+	Carp::croak("proxy_headers not set to an HTTP::Headers compatible object (got $desc)")
+	    unless @_ == 1 && blessed($arg) && $arg->can("header_field_names");
 	$self->{proxy_headers} = shift;
     }
     return $old;

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1041,6 +1041,10 @@ sub clone
         $copy->{def_headers} = $self->{def_headers}->clone;
     }
 
+    if ($self->{proxy_headers}) {
+        $copy->{proxy_headers} = $self->{proxy_headers}->clone;
+    }
+
     # re-enable standard handlers
     $copy->parse_head($self->parse_head);
 
@@ -1505,12 +1509,6 @@ The default is to not send a C<From> header.  See
 L<LWP::UserAgent/default_headers> for the more general interface that allow
 any header to be defaulted.
 
-=head2 proxy_headers
-
-    my $headers = $ua->proxy_headers;
-
-Get/set all headers that should be sent to proxies via CONNECT requests.
-
 
 =head2 local_address
 
@@ -1600,7 +1598,33 @@ will result in a 500 error.
     my $value = $ua->proxy_header( $field );
     $ua->proxy_header( $field => $value );
 
-Get/set headers that will only be sent to proxies via CONNECT requests.
+Get/set a single header that will be sent to proxies on the C<CONNECT>
+request used when tunneling HTTPS through an HTTP proxy. This is a shortcut
+for C<< $ua->proxy_headers->header( $field => $value ) >> and corresponds to
+curl's C<--proxy-header> option. A typical use is sending
+C<Proxy-Authorization> on the tunnel request without leaking it to the
+target server.
+
+See L<LWP::UserAgent/proxy_headers> for the underlying header object.
+
+C<proxy_header> is not accepted as a constructor argument; set it on an
+instance after construction.
+
+=head2 proxy_headers
+
+    my $headers = $ua->proxy_headers;
+    $ua->proxy_headers( $headers_obj );
+
+Get/set the L<HTTP::Headers> object holding the headers that will be sent on
+the C<CONNECT> request when tunneling HTTPS through an HTTP proxy. By
+default this will be an empty L<HTTP::Headers> object that is auto-vivified
+on first access. Setting accepts any object that C<< can("header_field_names") >>
+(i.e. an L<HTTP::Headers> or compatible subclass); passing a non-object or
+unblessed reference croaks.
+
+See L<LWP::UserAgent/proxy_header> for setting individual fields and
+L<LWP::UserAgent/default_headers> for the equivalent interface for normal
+(non-CONNECT) requests.
 
 =head2 requests_redirectable
 

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -1651,6 +1651,14 @@ C<Proxy-Authorization> automatically and that value takes precedence over
 anything in C<proxy_headers>. Either set the credentials via the proxy URL
 B<or> via C<proxy_headers>, not both.
 
+B<Note on connection caching>: when an L<LWP::ConnCache> is in use, the
+cache key is keyed only on host, port and tunnel target, not on the
+C<proxy_headers> contents. That means a previously established tunnel may
+be reused by a later request even after C<proxy_headers> has changed. If
+you need to rotate per-request headers (e.g. a one-shot proxy auth token),
+either disable the connection cache or call
+C<< $ua->conn_cache->prune >> between requests.
+
 =head2 requests_redirectable
 
     my $aref = $ua->requests_redirectable;

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -62,6 +62,8 @@ is($ua->default_header("Foo"),          "bar", '$ua->default_header("Foo")');
     my $ua_ctor = LWP::UserAgent->new(proxy_headers => $ph);
     is($ua_ctor->proxy_header('Proxy-Authorization'), 'Bearer x',
         'proxy_headers accepted as a constructor option');
+    is($ua_ctor->proxy_headers, $ph,
+        'constructor stores the same HTTP::Headers object (not a copy)');
 
     eval { LWP::UserAgent->new(proxy_headers => 'not an object') };
     like($@, qr/HTTP::Headers compatible object/,

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use HTTP::Headers ();
 use HTTP::Request ();
 use LWP::UserAgent ();
 use Test::More;
@@ -49,6 +50,22 @@ is(ref($ua->default_headers), "HTTP::Headers", 'ref($ua->default_headers)');
 $ua->default_header("Foo" => "bar", "Multi" => [1, 2]);
 is($ua->default_headers->header("Foo"), "bar", '$ua->default_headers->header("Foo")');
 is($ua->default_header("Foo"),          "bar", '$ua->default_header("Foo")');
+
+$ua->proxy_header("Foo" => "bar");
+is($ua->proxy_headers->header("Foo"), "bar", '$ua->proxy_headers->header("Foo")');
+is($ua->proxy_header("Foo"),          "bar", '$ua->proxy_header("Foo")');
+
+my $headers = HTTP::Headers->new(Bar => 'baz');
+$ua->proxy_headers($headers);
+is($ua->proxy_header('Bar'), 'baz', '$ua->proxy_headers accepts an HTTP::Headers object');
+
+eval { $ua->proxy_headers('not an object') };
+like($@, qr/HTTP::Headers compatible object/,
+    'proxy_headers croaks on non-object argument');
+
+eval { $ua->proxy_headers({ a => 1 }) };
+like($@, qr/HTTP::Headers compatible object/,
+    'proxy_headers croaks on unblessed hashref');
 
 # error on malformed request
 {

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -57,6 +57,17 @@ is($ua->default_header("Foo"),          "bar", '$ua->default_header("Foo")');
         '$ua->proxy_headers auto-vivifies an empty HTTP::Headers object');
 }
 
+{
+    my $ph = HTTP::Headers->new('Proxy-Authorization' => 'Bearer x');
+    my $ua_ctor = LWP::UserAgent->new(proxy_headers => $ph);
+    is($ua_ctor->proxy_header('Proxy-Authorization'), 'Bearer x',
+        'proxy_headers accepted as a constructor option');
+
+    eval { LWP::UserAgent->new(proxy_headers => 'not an object') };
+    like($@, qr/HTTP::Headers compatible object/,
+        'proxy_headers constructor option croaks on non-object');
+}
+
 $ua->proxy_header("Foo" => "bar");
 is($ua->proxy_headers->header("Foo"), "bar", '$ua->proxy_headers->header("Foo")');
 is($ua->proxy_header("Foo"),          "bar", '$ua->proxy_header("Foo")');

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -51,13 +51,29 @@ $ua->default_header("Foo" => "bar", "Multi" => [1, 2]);
 is($ua->default_headers->header("Foo"), "bar", '$ua->default_headers->header("Foo")');
 is($ua->default_header("Foo"),          "bar", '$ua->default_header("Foo")');
 
+{
+    my $fresh = LWP::UserAgent->new;
+    is(ref($fresh->proxy_headers), 'HTTP::Headers',
+        '$ua->proxy_headers auto-vivifies an empty HTTP::Headers object');
+}
+
 $ua->proxy_header("Foo" => "bar");
 is($ua->proxy_headers->header("Foo"), "bar", '$ua->proxy_headers->header("Foo")');
 is($ua->proxy_header("Foo"),          "bar", '$ua->proxy_header("Foo")');
 
 my $headers = HTTP::Headers->new(Bar => 'baz');
-$ua->proxy_headers($headers);
+my $old = $ua->proxy_headers($headers);
+isa_ok($old, 'HTTP::Headers', 'proxy_headers setter returns previous headers object');
 is($ua->proxy_header('Bar'), 'baz', '$ua->proxy_headers accepts an HTTP::Headers object');
+
+{
+    package MyHeaders;
+    our @ISA = ('HTTP::Headers');
+}
+my $sub = MyHeaders->new(Sub => 'class');
+$ua->proxy_headers($sub);
+is($ua->proxy_header('Sub'), 'class',
+    'proxy_headers accepts an HTTP::Headers subclass');
 
 eval { $ua->proxy_headers('not an object') };
 like($@, qr/HTTP::Headers compatible object/,
@@ -66,6 +82,17 @@ like($@, qr/HTTP::Headers compatible object/,
 eval { $ua->proxy_headers({ a => 1 }) };
 like($@, qr/HTTP::Headers compatible object/,
     'proxy_headers croaks on unblessed hashref');
+
+{
+    my $parent = LWP::UserAgent->new;
+    $parent->proxy_header('X-Parent' => 'one');
+    my $clone = $parent->clone;
+    $clone->proxy_header('X-Parent' => 'two');
+    is($parent->proxy_header('X-Parent'), 'one',
+        'clone has an independent proxy_headers object');
+    is($clone->proxy_header('X-Parent'), 'two',
+        'clone retains its own proxy_header changes');
+}
 
 # error on malformed request
 {

--- a/t/base/ua.t
+++ b/t/base/ua.t
@@ -58,6 +58,24 @@ is($ua->default_header("Foo"),          "bar", '$ua->default_header("Foo")');
 }
 
 {
+    my $fresh = LWP::UserAgent->new;
+    is($fresh->proxy_header('X-Missing'), undef,
+        'proxy_header($field) returns undef when no headers are set');
+    ok(!exists $fresh->{proxy_headers},
+        'proxy_header($field) does not auto-vivify the headers object');
+
+    $fresh->proxy_header('X-Set' => 'yes');
+    ok(exists $fresh->{proxy_headers},
+        'proxy_header($field => $value) auto-vivifies as a setter');
+}
+
+{
+    my $ua_undef = LWP::UserAgent->new(proxy_headers => undef);
+    ok(!exists $ua_undef->{proxy_headers},
+        'proxy_headers => undef in constructor leaves slot unset');
+}
+
+{
     my $ph = HTTP::Headers->new('Proxy-Authorization' => 'Bearer x');
     my $ua_ctor = LWP::UserAgent->new(proxy_headers => $ph);
     is($ua_ctor->proxy_header('Proxy-Authorization'), 'Bearer x',


### PR DESCRIPTION
Supersedes #92 (whose source fork was deleted, blocking further updates).

Rebased Mathias Fischer's original commits onto current `master` and resolved POD/test conflicts caused by the upstream switch from `=item` lists to `=head2` sections and from `plan tests => N` to `done_testing()`.

## Summary

- Adds `proxy_header($field [, $value])` to get/set individual headers for proxy CONNECT requests
- Adds `proxy_headers([$headers_obj])` to get/set the full `HTTP::Headers` object
- `LWP::Protocol::http` passes those headers on the `CONNECT` request when tunneling

This corresponds to curl's `--proxy-header` option.

Usage:

```perl
require LWP::UserAgent;

my $ua = LWP::UserAgent->new;
$ua->proxy(['http', 'https'], 'http://proxy.example.com');
$ua->proxy_header('User-Agent' => 'Special Agent');
```

## Test plan

- [x] `prove -lv t/base/ua.t` — all 53 tests pass locally
- [ ] CI green