### PR TITLE
Caller-set Proxy-Authorization wins over proxy URL userinfo

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Caller-set Proxy-Authorization now takes precedence over proxy URL
+      userinfo in LWP::Protocol::http::_fixup_header, matching the existing
+      Authorization behaviour. Behaviour change: previously the userinfo
+      silently overrode any explicit header (GH#506) (Olaf Alders, Claude).
 
 6.82      2026-03-29 17:02:10Z
     - Fix env_proxy() warning for unrelated environment variables (GH#501)

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -106,7 +106,7 @@ sub _fixup_header
 	# export http_proxy="http://proxyuser:proxypass@proxyhost:port".
 	# For https only the initial CONNECT requests needs authorization.
 	my $p_auth = $proxy->userinfo();
-	if(defined $p_auth) {
+	if (defined $p_auth && not $h->header('Proxy-Authorization')) {
 	    require URI::Escape;
 	    $h->proxy_authorization_basic(map URI::Escape::uri_unescape($_),
 					  split(":", $p_auth, 2))

--- a/t/base/proxy_authorization.t
+++ b/t/base/proxy_authorization.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use HTTP::Headers ();
+use Test::More;
+use URI ();
+
+use LWP::Protocol::http ();
+
+# Tiny subclass so we can call the private _fixup_header without spinning
+# up an LWP::UserAgent. Decouples the test from LWP::Protocol::new's
+# internals — _fixup_header only reads its arguments.
+{
+    package Test::FixupProto;
+    use parent -norequire, 'LWP::Protocol::http';
+    sub new { bless {}, shift }
+}
+
+my $proto = Test::FixupProto->new;
+my $url   = URI->new('http://target.example.com/');
+
+subtest 'no proxy userinfo: caller-set Proxy-Authorization preserved' => sub {
+    my $proxy = URI->new('http://proxy.example:3128');
+    my $h = HTTP::Headers->new('Proxy-Authorization' => 'Bearer caller-token');
+    $proto->_fixup_header($h, $url, $proxy);
+    is($h->header('Proxy-Authorization'), 'Bearer caller-token',
+        'caller-set header is unchanged when proxy URL has no userinfo');
+};
+
+subtest 'proxy userinfo, no caller header: userinfo populates' => sub {
+    my $proxy = URI->new('http://user:pass@proxy.example:3128');
+    my $h = HTTP::Headers->new;
+    $proto->_fixup_header($h, $url, $proxy);
+    is($h->header('Proxy-Authorization'), 'Basic dXNlcjpwYXNz',
+        'userinfo populates Proxy-Authorization when none is set');
+};
+
+subtest 'proxy userinfo + caller header: caller wins' => sub {
+    my $proxy = URI->new('http://user:pass@proxy.example:3128');
+    my $h = HTTP::Headers->new('Proxy-Authorization' => 'Bearer caller-token');
+    $proto->_fixup_header($h, $url, $proxy);
+    is($h->header('Proxy-Authorization'), 'Bearer caller-token',
+        'caller-set header wins over proxy URL userinfo');
+};
+
+subtest 'https request URL: userinfo block is skipped entirely' => sub {
+    my $https_url = URI->new('https://target.example.com/');
+    my $proxy     = URI->new('http://user:pass@proxy.example:3128');
+    my $h = HTTP::Headers->new;
+    $proto->_fixup_header($h, $https_url, $proxy);
+    is($h->header('Proxy-Authorization'), undef,
+        'userinfo is not applied when target URL is https (CONNECT path)');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- Closes #506.
- One-line guard in `LWP::Protocol::http::_fixup_header`: only populate `Proxy-Authorization` from `$proxy->userinfo()` when the caller has not already set the header. Mirrors the existing `Authorization` branch immediately above.
- New `t/base/proxy_authorization.t` covering the four relevant cases (no userinfo, userinfo populates, caller wins, https/CONNECT path skipped).
- `Changes` entry flags this as a behaviour change for review.

## Behaviour change

Callers who today rely on `Proxy-Authorization` being silently overridden by `http://user:pass@proxy/` userinfo will see their explicit header preserved instead. The new behaviour matches:

- the parallel `Authorization` handling four lines above, and
- the typical "caller-explicit beats inferred" expectation (e.g. how `init_header` works elsewhere).

A scan of the codebase did not find any internal callers relying on the old override semantics. Maintainers: please confirm this trade-off is acceptable before merging.

## Relationship to #463
PR #463 (the `proxy_header` feature) does not touch `_fixup_header` — no semantic conflict. Whichever lands second will get a trivial textual rebase.

## Test plan
- [x] `prove -lv t/base/proxy_authorization.t` — all 4 subtests pass
- [ ] Maintainer confirms the behaviour change is acceptable
- [ ] Full local test suite green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)