### PR TITLE
Fingerprint proxy userinfo in LWP::ConnCache tunnel key

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - Include the proxy URL's userinfo in the LWP::ConnCache key for HTTPS-
+      through-HTTP-proxy tunnels. Rotating proxy credentials between requests
+      now correctly re-establishes the tunnel instead of silently reusing one
+      negotiated with the previous credentials. Behaviour change: callers
+      rotating per-request credentials will see one extra TCP+TLS handshake
+      per token (GH#507) (Olaf Alders, Claude).
 
 6.82      2026-03-29 17:02:10Z
     - Fix env_proxy() warning for unrelated environment variables (GH#501)

--- a/lib/LWP/Protocol/http.pm
+++ b/lib/LWP/Protocol/http.pm
@@ -114,6 +114,31 @@ sub _fixup_header
     }
 }
 
+sub _conn_cache_key {
+    my ($self, $host, $port, $ssl_tunnel, $proxy) = @_;
+
+    # Base key: which TCP endpoint we connected to. For non-tunnel use this
+    # is enough — every request sends its own headers down the socket, so
+    # reuse is safe regardless of header churn.
+    my $key = "$host:$port";
+    return $key unless $ssl_tunnel;
+
+    # Tunnel keys must additionally fingerprint anything that gets baked
+    # into the synthetic CONNECT request. A cached tunnel was negotiated
+    # with one set of CONNECT headers; reusing it for a request that would
+    # have produced different CONNECT headers silently bypasses the new
+    # values. Today the only varying input is the proxy URL's userinfo —
+    # _fixup_header derives Proxy-Authorization from it. The Host header
+    # is fully determined by $ssl_tunnel.
+    #
+    # INVARIANT: any input that influences the CONNECT request must be
+    # reflected here, otherwise rotating it between requests will be
+    # silently dropped.
+    my $userinfo = defined($proxy) && defined($proxy->userinfo)
+        ? $proxy->userinfo : '';
+    return "$key!$ssl_tunnel\0$userinfo";
+}
+
 sub hlist_remove {
     my($hlist, $k) = @_;
     $k = lc $k;
@@ -168,12 +193,7 @@ sub request
     my $conn_cache = $self->{ua}{conn_cache};
     my $cache_key;
     if ( $conn_cache ) {
-	$cache_key = "$host:$port";
-	# For https we reuse the socket immediately only if it has an established
-	# tunnel to the target. Otherwise a CONNECT request followed by an SSL
-	# upgrade need to be done first. The request itself might reuse an
-	# existing non-ssl connection to the proxy
-	$cache_key .= "!".$ssl_tunnel if $ssl_tunnel;
+	$cache_key = $self->_conn_cache_key($host, $port, $ssl_tunnel, $proxy);
 	if ( $socket = $conn_cache->withdraw($self->socket_type,$cache_key)) {
 	    if ($socket->can_read(0)) {
 		# if the socket is readable, then either the peer has closed the

--- a/t/base/conn_cache_key.t
+++ b/t/base/conn_cache_key.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use Test::More;
+use URI ();
+
+use LWP::Protocol::http ();
+
+# Tiny subclass so we can call the private _conn_cache_key without
+# spinning up an LWP::UserAgent. Decouples the test from
+# LWP::Protocol::new's internals — _conn_cache_key only reads its
+# arguments.
+{
+    package Test::CacheKeyProto;
+    use parent -norequire, 'LWP::Protocol::http';
+    sub new { bless {}, shift }
+}
+
+my $proto = Test::CacheKeyProto->new;
+
+sub key {
+    my ($target, $proxy_url) = @_;
+    my $url   = URI->new($target);
+    my $proxy = URI->new($proxy_url);
+    my $ssl_tunnel = $url->scheme eq 'https' ? $url->host_port : undef;
+    my ($host, $port) = ($proxy->host, $proxy->port);
+    return $proto->_conn_cache_key($host, $port, $ssl_tunnel, $proxy);
+}
+
+subtest 'plain HTTP through proxy: userinfo does not split the cache' => sub {
+    # Rationale: for non-tunnel requests, every request carries its own
+    # headers over the socket, so reuse is safe. Splitting the cache here
+    # would defeat keep-alive for callers rotating proxy creds without any
+    # correctness benefit.
+    my $a = key('http://target/', 'http://user1:pass@proxy:3128');
+    my $b = key('http://target/', 'http://user2:pass@proxy:3128');
+    is($a, $b, 'plain HTTP cache key ignores proxy userinfo');
+    is($a, 'proxy:3128', 'plain HTTP key is just host:port');
+};
+
+subtest 'HTTPS tunnel: same userinfo + same target is the same key' => sub {
+    my $a = key('https://target:443/', 'http://user:pass@proxy:3128');
+    my $b = key('https://target:443/', 'http://user:pass@proxy:3128');
+    is($a, $b, 'identical inputs produce identical keys');
+};
+
+subtest 'HTTPS tunnel: different userinfo splits the cache' => sub {
+    # The actual bug fix. Previously these collided to one key and the
+    # second request silently reused a tunnel negotiated with the first
+    # token.
+    my $a = key('https://target:443/', 'http://token1@proxy:3128');
+    my $b = key('https://target:443/', 'http://token2@proxy:3128');
+    isnt($a, $b, 'rotating proxy userinfo produces distinct cache keys');
+};
+
+subtest 'HTTPS tunnel: missing userinfo vs present userinfo splits' => sub {
+    my $a = key('https://target:443/', 'http://proxy:3128');
+    my $b = key('https://target:443/', 'http://user:pass@proxy:3128');
+    isnt($a, $b, 'absent vs present userinfo are distinguishable');
+};
+
+subtest 'HTTPS tunnel: same proxy + different target hosts split' => sub {
+    # Already true on master via $ssl_tunnel; verify the helper preserves
+    # that.
+    my $a = key('https://target1:443/', 'http://user:pass@proxy:3128');
+    my $b = key('https://target2:443/', 'http://user:pass@proxy:3128');
+    isnt($a, $b, 'different target hosts produce distinct cache keys');
+};
+
+subtest 'no proxy: key is just host:port of target' => sub {
+    my $url = URI->new('http://target:8080/');
+    my $k = $proto->_conn_cache_key($url->host, $url->port, undef, undef);
+    is($k, 'target:8080', 'direct connection key is host:port');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- Closes #507.
- Cache-key construction for HTTPS-through-HTTP-proxy tunnels now includes the proxy URL's userinfo. Rotating proxy credentials per request will correctly negotiate a fresh CONNECT tunnel each time instead of silently reusing one bound to the previous credentials.
- Factored the cache-key logic into a private `_conn_cache_key` helper so it's testable without spinning up sockets.
- Non-tunnel path is unchanged on purpose (see below).

## Why only the tunnel path?

For plain HTTP through a proxy, every request sends its own headers down the socket — `Proxy-Authorization` is per-request, so socket reuse is correctness-safe regardless of header churn. Splitting that cache by userinfo would regress keep-alive for callers rotating credentials with no functional payoff.

The CONNECT/tunnel case is different: the credentials get baked into the persistent socket state at tunnel-establishment time and never re-sent. That's where the cache key needs the extra disambiguation.

## Behaviour change
Callers that today rotate proxy credentials per request and (incorrectly) believe each request re-negotiates the tunnel will, after this fix, actually do so. That means one extra TCP+TLS handshake per distinct credential. The `Changes` entry calls this out.

Callers using a single set of credentials (the common case) are unaffected — same key, same reuse.

## Invariant
The new helper carries an inline comment stating the invariant: anything that flows into the synthetic CONNECT request must be reflected in the cache key. Today that's the proxy userinfo (via `_fixup_header` → `Proxy-Authorization`) and `$ssl_tunnel` (the target host:port, which is already in the key). Future changes that add inputs to the CONNECT — e.g. PR #505's `proxy_headers` if it lands — will need to extend `_conn_cache_key` accordingly. The comment names this so the next person doesn't reintroduce the bug silently.

## Test plan
- [x] `prove -lv t/base/conn_cache_key.t` — 6 subtests pass
- [x] `prove -l t/base/` — full base suite (103 tests) green
- [ ] Maintainer confirms the behaviour change is acceptable

## Relationship to other PRs
- Independent of #510 (proxy-auth precedence) — they touch different code paths and share no conflict.
- Independent of #463 / #505 (`proxy_headers` accessor). When #505 lands, a small follow-up adds `proxy_headers` to `_conn_cache_key`'s fingerprint input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)