### PR TITLE
Stop default_headers re-leaking stripped credentials across redirects

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,17 @@
 Change history for libwww-perl
 
 {{$NEXT}}
+    - LWP::UserAgent no longer re-applies persistent default headers
+      (default_header/default_headers) that were stripped from a redirect
+      referral. Previously prepare_request() re-initialised a default
+      Authorization, Proxy-Authorization, or Cookie onto the cross-origin
+      target after request() had stripped it, defeating the CVE-2026-8368
+      mitigation for the persistent-header path. Same-origin redirects and
+      allow_credentialed_redirects => 1 retain credentials as before.
+    - Simplify the cross-origin credential strip comparison to use
+      URI->canonical and host_port, keeping it consistent with the rest of
+      the module and removing an inconsistent host/port guard. No behavior
+      change for the http/https redirect targets this code handles. (GH#526)
 
 6.83      2026-05-12 11:41:48Z
     - LWP::UserAgent now strips Authorization and Proxy-Authorization headers

--- a/lib/LWP/UserAgent.pm
+++ b/lib/LWP/UserAgent.pm
@@ -263,7 +263,14 @@ sub prepare_request
     $self->run_handlers("request_preprepare", $request);
 
     if (my $def_headers = $self->{def_headers}) {
+	# Headers that request() deliberately stripped from a redirect
+	# referral (e.g. Authorization on a cross-origin hop, or Cookie on
+	# any hop) must not be silently re-applied here from default_headers,
+	# which would re-leak them. See request() for how the set is built.
+	my %skip = map { lc $_ => 1 }
+	    @{ $self->{_stripped_redirect_headers} || [] };
 	for my $h ($def_headers->header_field_names) {
+	    next if $skip{ lc $h };
 	    $request->init_header($h => [$def_headers->header($h)]);
 	}
     }
@@ -325,6 +332,10 @@ sub request {
     }
 
     if (my $req = $self->run_handlers("response_redirect", $response)) {
+        # A response_redirect handler owns the referral request it returns,
+        # including any cross-origin credential decision, so this path
+        # intentionally bypasses the built-in strip and its
+        # _stripped_redirect_headers tracking below.
         return $self->request($req, $arg, $size, $response);
     }
 
@@ -338,8 +349,15 @@ sub request {
     {
         my $referral = $request->clone;
 
+        # Names of headers we deliberately strip from the referral below.
+        # Carried (cumulatively) across the redirect chain via a localized
+        # field so prepare_request() does not re-apply them from
+        # default_headers on this or any later hop and re-leak them.
+        my @stripped = @{ $self->{_stripped_redirect_headers} || [] };
+
         # These headers should never be forwarded
         $referral->remove_header('Host', 'Cookie');
+        push @stripped, 'Host', 'Cookie';
 
         if (   $referral->header('Referer')
             && $request->uri->scheme eq 'https'
@@ -348,6 +366,7 @@ sub request {
             # RFC 2616, section 15.1.3.
             # https -> http redirect, suppressing Referer
             $referral->remove_header('Referer');
+            push @stripped, 'Referer';
         }
 
         if (   $code == HTTP::Status::RC_SEE_OTHER
@@ -379,19 +398,20 @@ sub request {
         # libcurl CVE-2018-1000007. Opt-out via
         # allow_credentialed_redirects => 1.
         unless ($self->{allow_credentialed_redirects}) {
-            my $orig = $request->uri;
-            my $new  = $referral->uri;
+            # canonical() lower-cases scheme and host, and host_port supplies
+            # the scheme's default port when none is given, so http://h/ and
+            # http://h:80/ (and case-only host differences) compare equal.
+            # The scheme comparison short-circuits the || below, so a host-less
+            # scheme (mailto:, data:) never reaches host_port, which would die.
+            my $orig = $request->uri->canonical;
+            my $new  = $referral->uri->canonical;
             my $orig_scheme = defined $orig->scheme ? $orig->scheme : q{};
             my $new_scheme  = defined $new->scheme  ? $new->scheme  : q{};
-            my $orig_host   = defined $orig->host   ? lc $orig->host : q{};
-            my $new_host    = defined $new->host    ? lc $new->host  : q{};
-            my $orig_port   = eval { $orig->port } || 0;
-            my $new_port    = eval { $new->port  } || 0;
             if (   $orig_scheme ne $new_scheme
-                || $orig_host   ne $new_host
-                || $orig_port   != $new_port)
+                || $orig->host_port ne $new->host_port)
             {
                 $referral->remove_header('Authorization', 'Proxy-Authorization');
+                push @stripped, 'Authorization', 'Proxy-Authorization';
             }
         }
 
@@ -411,6 +431,7 @@ sub request {
         }
 
         return $response unless $self->redirect_ok($referral, $response);
+        local $self->{_stripped_redirect_headers} = \@stripped;
         return $self->request($referral, $arg, $size, $response);
 
     }
@@ -1448,11 +1469,18 @@ with an optional version number separated by the C</> character.
     my $allow = $ua->allow_credentialed_redirects;
     $ua->allow_credentialed_redirects( 1 );
 
-Get/set whether caller-supplied C<Authorization> and C<Proxy-Authorization>
-headers are forwarded across cross-origin 3xx redirects (a different scheme,
-host, or port). Defaults to a false value, meaning the headers are stripped
-on cross-origin redirects to avoid leaking credentials to the redirect target.
+Get/set whether C<Authorization> and C<Proxy-Authorization> headers are
+forwarded across cross-origin 3xx redirects (a different scheme, host, or
+port). Defaults to a false value, meaning the headers are stripped on
+cross-origin redirects to avoid leaking credentials to the redirect target.
 Same-origin redirects always retain these headers.
+
+This applies both to headers carried on the request and to persistent
+headers set via L</default_header> / L</default_headers>: a persistent
+credential header is not re-applied to a cross-origin redirect target while
+this is false. (A C<Cookie> set via the persistent headers is dropped on
+every redirect regardless of this setting, mirroring the unconditional
+C<Cookie> strip.)
 
 =head2 allow_downgrade
 
@@ -1554,6 +1582,13 @@ C<< $ua->default_headers->header( $field => $value ) >>.
 Get/set the headers object that will provide default header values for
 any requests sent.  By default this will be an empty L<HTTP::Headers>
 object.
+
+Default headers are applied to redirect referrals as well, but any header
+that the redirect handling deliberately strips from a referral is not
+re-applied from the defaults on that hop or any later one. In addition to
+the credential headers described under L</allow_credentialed_redirects>,
+this covers C<Host> (always recomputed per target) and, on an
+https-to-http hop, C<Referer> (suppressed per RFC 2616 section 15.1.3).
 
 =head2 from
 

--- a/t/redirect-default-header-leak.t
+++ b/t/redirect-default-header-leak.t
@@ -1,0 +1,261 @@
+use strict;
+use warnings;
+
+# Regression test: companion hardening to the CVE-2026-8368 cross-origin
+# credential strip. A persistent header set via
+# default_header()/default_headers must not be re-applied to a cross-origin
+# redirect target by prepare_request(). LWP strips
+# Authorization/Proxy-Authorization (and Cookie) on redirects; prepare_request
+# re-initialises default headers via init_header(), which would silently put
+# the stripped credential right back on the cross-origin referral and defeat
+# the strip.
+#
+# These tests override send_request (not simple_request) so prepare_request --
+# the code path that re-applies default_headers -- runs for real, while LWP's
+# actual redirect loop in request() drives the cross-origin handling.
+
+use Test::More;
+use HTTP::Request ();
+use HTTP::Response ();
+
+{
+    package Test::PrepareUA;
+    use parent 'LWP::UserAgent';
+
+    sub new {
+        my ($class, %opts) = @_;
+        my $responses = delete $opts{_responses} || [];
+        my $self = $class->SUPER::new(%opts);
+        $self->{_responses} = $responses;
+        $self->{_requests}  = [];
+        return $self;
+    }
+
+    # Capture the request as it is actually put on the wire -- i.e. after
+    # prepare_request() has applied default_headers.
+    sub send_request {
+        my ($self, $req) = @_;
+        push @{ $self->{_requests} }, $req->clone;
+        my $resp = shift @{ $self->{_responses} }
+            || HTTP::Response->new(500, 'no canned response');
+        $resp->request($req);
+        return $resp;
+    }
+}
+
+sub make_redirect {
+    my ($location) = @_;
+    my $r = HTTP::Response->new(302, 'Found');
+    $r->header(Location => $location);
+    return $r;
+}
+
+sub make_ok {
+    my $r = HTTP::Response->new(200, 'OK');
+    $r->content('done');
+    return $r;
+}
+
+subtest 'cross-host redirect does not re-apply default Authorization' => sub {
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://attacker.example/loot'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization'       => 'Bearer s3cr3t');
+    $ua->default_header('Proxy-Authorization' => 'Basic cHJveHk6c2VjcmV0');
+
+    my $res = $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    is(scalar @{ $ua->{_requests} }, 2, 'two requests issued');
+    my $first = $ua->{_requests}->[0];
+    is($first->header('Authorization'), 'Bearer s3cr3t',
+        'first request carries the default Authorization');
+
+    my $followup = $ua->{_requests}->[1];
+    is($followup->uri, 'http://attacker.example/loot', 'followup hit redirect target');
+    is($followup->header('Authorization'), undef,
+        'default Authorization NOT re-applied cross-host');
+    is($followup->header('Proxy-Authorization'), undef,
+        'default Proxy-Authorization NOT re-applied cross-host');
+    is($res->code, 200, 'final response is 200');
+};
+
+subtest 'cross-host redirect does not re-apply default Cookie' => sub {
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://attacker.example/loot'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Cookie' => 'session=s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    my $followup = $ua->{_requests}->[1];
+    is($followup->header('Cookie'), undef,
+        'default Cookie NOT re-applied cross-host');
+};
+
+subtest 'same-origin redirect keeps default Authorization' => sub {
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://victim.example/profile/new'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    my $followup = $ua->{_requests}->[1];
+    is($followup->header('Authorization'), 'Bearer s3cr3t',
+        'default Authorization preserved same-origin');
+};
+
+subtest 'default vs explicit default port is same-origin, keeps Authorization' => sub {
+    # http://victim.example -> http://victim.example:80 is the same origin:
+    # canonical()/host_port supplies the scheme default port, so the explicit
+    # :80 must compare equal and the credential must survive. Locks in the
+    # canonicalization the cross-origin comparison relies on.
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://victim.example:80/profile/new'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    my $followup = $ua->{_requests}->[1];
+    is($followup->header('Authorization'), 'Bearer s3cr3t',
+        'default Authorization retained across default/explicit port (same origin)');
+};
+
+subtest 'same-origin redirect still drops default Cookie' => sub {
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://victim.example/profile/new'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+    $ua->default_header('Cookie'        => 'session=s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    my $followup = $ua->{_requests}->[1];
+    # Cookie is stripped on every redirect, so the default must not bring it
+    # back even same-origin, while Authorization (origin-gated) survives.
+    is($followup->header('Authorization'), 'Bearer s3cr3t',
+        'default Authorization retained same-origin');
+    is($followup->header('Cookie'), undef,
+        'default Cookie dropped even same-origin');
+};
+
+subtest 'allow_credentialed_redirects re-applies default Authorization cross-host' => sub {
+    my $ua = Test::PrepareUA->new(
+        allow_credentialed_redirects => 1,
+        _responses => [
+            make_redirect('http://attacker.example/loot'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+    $ua->default_header('Cookie'        => 'session=s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    my $followup = $ua->{_requests}->[1];
+    is($followup->header('Authorization'), 'Bearer s3cr3t',
+        'default Authorization forwarded under allow_credentialed_redirects');
+    # Cookie stripping is unconditional, so the opt-in must not restore it.
+    is($followup->header('Cookie'), undef,
+        'default Cookie still dropped despite allow_credentialed_redirects');
+};
+
+subtest 'non-credential default header still applied on cross-host redirect' => sub {
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://attacker.example/loot'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('X-Trace' => 'abc123');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+
+    my $followup = $ua->{_requests}->[1];
+    is($followup->header('X-Trace'), 'abc123',
+        'non-sensitive default header is still applied across redirect');
+};
+
+subtest 'multi-hop: default Authorization stays stripped after returning same-origin' => sub {
+    # hosta -> hostb (cross, strip) -> hostb/next (same-origin to prior hop).
+    # The default Authorization must not reappear on the second hop just
+    # because that hop did not itself cross an origin boundary.
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://hostb.example/step'),
+            make_redirect('http://hostb.example/final'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://hosta.example/start'));
+
+    is(scalar @{ $ua->{_requests} }, 3, 'three requests issued');
+    is($ua->{_requests}->[1]->header('Authorization'), undef,
+        'Authorization stripped on first cross-origin hop');
+    is($ua->{_requests}->[2]->header('Authorization'), undef,
+        'Authorization NOT re-applied on same-origin hop after crossing origin');
+};
+
+subtest 'multi-hop: default Authorization stays stripped returning to origin' => sub {
+    # hosta -> hostb (cross, strip) -> hosta (back to the original origin).
+    # The cumulative strip is conservative: once dropped on a foreign hop the
+    # credential is not resurrected even when the chain returns home.
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            make_redirect('http://hostb.example/step'),
+            make_redirect('http://hosta.example/final'),
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://hosta.example/start'));
+
+    is(scalar @{ $ua->{_requests} }, 3, 'three requests issued');
+    is($ua->{_requests}->[2]->uri, 'http://hosta.example/final',
+        'final hop is back on the original origin');
+    is($ua->{_requests}->[2]->header('Authorization'), undef,
+        'Authorization not resurrected on return to original origin');
+};
+
+subtest 'strip tracking does not leak across separate top-level requests' => sub {
+    my $ua = Test::PrepareUA->new(
+        _responses => [
+            # First request: cross-origin redirect that strips Authorization.
+            make_redirect('http://attacker.example/loot'),
+            make_ok(),
+            # Second, independent request: no redirect.
+            make_ok(),
+        ],
+    );
+    $ua->default_header('Authorization' => 'Bearer s3cr3t');
+
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/profile'));
+    is($ua->{_requests}->[1]->header('Authorization'), undef,
+        'Authorization stripped on first request cross-origin hop');
+
+    # A fresh top-level request must start with a clean strip set.
+    $ua->request(HTTP::Request->new(GET => 'http://victim.example/again'));
+    is($ua->{_requests}->[2]->header('Authorization'), 'Bearer s3cr3t',
+        'default Authorization applied normally on the next top-level request');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

`LWP::UserAgent` strips `Authorization`/`Proxy-Authorization` on cross-origin
redirects and `Cookie` on every redirect (the CVE-2026-8368 mitigation).
However `prepare_request()` re-applied persistent default headers (set via
`default_header` / `default_headers`) through `init_header()` *after* the
strip, putting a default `Authorization`, `Proxy-Authorization`, or `Cookie`
right back onto the cross-origin redirect target — defeating the strip for the
persistent-header path. This is the `LWP::UserAgent` companion to the
`WWW::Mechanize` `add_header` leak fixed in libwww-perl/WWW-Mechanize#433.

## Changes

- `request()` records the header names it deliberately strips from a redirect
  referral (`Host`, `Cookie`, conditionally `Referer`, and
  `Authorization`/`Proxy-Authorization` on a cross-origin hop), accumulated
  across the whole redirect chain via a localized
  `$self->{_stripped_redirect_headers}`.
- `prepare_request()` skips re-applying those names from `default_headers`, so
  a stripped credential is not silently re-injected on the referral or any
  later hop.
- `allow_credentialed_redirects => 1` still forwards
  `Authorization`/`Proxy-Authorization`; `Cookie` is always dropped.
- Simplify the cross-origin comparison to use `URI->canonical` + `host_port`,
  matching the rest of the module and removing an inconsistent host/port
  guard, with no behavior change for the http/https targets this code handles.
  Closes #526.

## Testing

- New `t/redirect-default-header-leak.t` drives LWP's real redirect loop over a
  mocked transport (overriding `send_request`, so `prepare_request` runs) and
  asserts the default-header path: cross-host strip of Authorization,
  Proxy-Authorization, and Cookie; same-origin retention of Authorization;
  unconditional Cookie drop; the `allow_credentialed_redirects` opt-in; a
  non-credential default header still applied; and multi-hop cases
  (same-origin after a cross-origin hop, return to the original origin, and no
  state leak across separate top-level requests).
- Red-green verified: 7/9 new subtests fail with the fix disabled.
- Full suite passes (173 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
