### PR TITLE
Changelog: note CVE-2010-10018 on the 5.835 CRLF-injection fix

### DIFF
--- a/Changes
+++ b/Changes
@@ -521,7 +521,8 @@ Change history for libwww-perl
     - Documentation grammar fixes.
     - Use $uri->secure in m_secure if available.
     - Fix handling of multiple (same) base headers, and parameters in them.
-    - Strip out empty lines separated by CRLF
+    - Strip out empty lines separated by CRLF, preventing a CRLF injection in
+      header serialization (CVE-2010-10018, commit efb15853) (Mark Stosberg)
     - Best Practice: avoid indirect object notation
     - Speed up as_string by 4% by having _sorted_field_names return a reference
     - Speed up scan() a bit. as_string() from this branch is now 6% faster


### PR DESCRIPTION
Annotate the existing 5.835 "Strip out empty lines separated by CRLF"
entry with the retroactively assigned CVE-2010-10018 and the fixing
commit efb15853, and credit Mark Stosberg, per CPAN-Security/cna-cve#298.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
